### PR TITLE
TANIP-1 Production Deployments

### DIFF
--- a/src/data/tanIssuanceHistories.ts
+++ b/src/data/tanIssuanceHistories.ts
@@ -11,17 +11,10 @@ export type TanIssuanceHistory = {
 
 export const tanIssuanceHistories = [
   {
-    //todo: mock polygon TANIssuanceHistory (for testing only, remove and replace with prod deployment)
     chain: ChainId.Polygon,
-    address: "0xcAE9a3227C93905418500498F65f5d2baB235511",
+    address: "0xfAf4E75BF9CD392e56Bffb574820126ce4212744",
     abi: TanIssuanceHistoryAbi,
   },
-  // {
-  //   // prod polygon TANIssuanceHistory
-  //   chain: ChainId.Polygon,
-  //   address: "todo: awaiting prod deployment of new plugin to prod StakingModule & increaser role set to TanIssuanceHistory",
-  //   abi: TanIssuanceHistoryAbi,
-  // },
 ].map((tanIssuanceHistory) => {
   return {
     ...tanIssuanceHistory,

--- a/src/datasources/SimplePlugin.ts
+++ b/src/datasources/SimplePlugin.ts
@@ -103,11 +103,8 @@ export class SimplePlugin extends BaseSimplePlugin {
     const logs = await publicClient.getLogs({
       address: this.pluginAddress,
       event: this.claimableIncreasedEvent,
-      // },
-      // this.chain,
       fromBlock: this.startBlock,
       toBlock: this.endBlock,
-      // this.showLogs
     });
 
     return logs.map((log) => ({

--- a/src/staker-incentives-calculator.md
+++ b/src/staker-incentives-calculator.md
@@ -115,11 +115,6 @@ For each validated user fee transfer, the `fetchUserFeeTransfers()` function als
 
 - `0x4eB4A35257458C1a87A4124CE02B3329Ed6b8D5a`
 
-> **To be Deprecated:**
-
-- `0x5c4Bb7067199f91a432Ae5F90C742967CfDF7E50`
-- `0xfBBB07E82c771489f2256f82060CAB17DB14c18f`
-
 #### **Staking Contract**
 
 - Locks staked TEL for all `Stakers` and `Referrers`:
@@ -127,14 +122,8 @@ For each validated user fee transfer, the `fetchUserFeeTransfers()` function als
 
 #### **Staking Plugins**
 
-- `SimplePlugin` contracts emit `ClaimableIncreased` events for deriving `Referrer <-> Referee` relationships:
-- Awaiting deployment to production
-
-> **To be Deprecated:**
-
-- `0x2f3378850a8fD5a0428a3967c2Ef6aAA025a4E1D`
-- `0xe24f8d36405704e85945a639fdaCEc47bA2a7c88`
+- `0xd8e7a80570d37D3fBe6eD5228c75475c81cEd094`
 
 #### **TANIssuanceHistory**
 
-- Awaiting deployment to production
+- `0xfAf4E75BF9CD392e56Bffb574820126ce4212744`


### PR DESCRIPTION
Add newly deployed TANIssuanceHistory contract `0xfAf4E75BF9CD392e56Bffb574820126ce4212744 `, which is set to serve the increaser role for the TANIP-1 SimplePlugin deployed at `0xd8e7a80570d37D3fBe6eD5228c75475c81cEd094`

Deprecate old AmirX contracts which will not be relevant for TANIP-1