### PR TITLE
Strip out BlocksDB, replace with tx fetching

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,9 +11,7 @@ import {
   parseAndSanitizeCLIArgs,
   writeIncentivesToFile,
 } from "./helpers";
-import { DeveloperIncentivesCalculator } from "./calculators/DeveloperIncentivesCalculator";
 import { SimplePlugin } from "./datasources/SimplePlugin";
-import { LocalFileUserRegistry } from "./datasources/UserRegistry";
 import { TokenTransferHistory } from "./datasources/TokenTransferHistory";
 import { StakerIncentivesCalculator } from "./calculators/StakerIncentivesCalculator";
 import { aggregators } from "./data/aggregators";
@@ -21,7 +19,6 @@ import { amirXs } from "./data/amirXs";
 import { stakingModules } from "./data/stakingModules";
 import { tanIssuanceHistories } from "./data/tanIssuanceHistories";
 import { Address, createPublicClient, http } from "viem";
-import { addressResolverAbi } from "viem/_types/constants/abis";
 import { polygon } from "viem/chains";
 
 // Track active database connections
@@ -50,12 +47,6 @@ async function main() {
   // the executor registry keeps track of each developer's executors
   console.log("Initializing executor registry...");
   const executorRegistry = new LocalFileExecutorRegistry();
-
-  // blocks databases fetch and store block data on disk
-  console.log("Initializing blocks databases...");
-  const polygonBlocksDatabase = new BlocksDatabase(ChainId.Polygon);
-  // track active database for cleanup
-  activeBlocksDatabases.push(polygonBlocksDatabase);
 
   // TokenTransferHistory fetches and stores ERC20 transfer events
   console.log("Initializing token transfer history...");
@@ -95,7 +86,6 @@ async function main() {
   // This calculator calculates the referrals incentives for each staker
   console.log("Initializing stakers incentives calculator...");
   const polygonStakerIncentivesCalculator = new StakerIncentivesCalculator(
-    [polygonBlocksDatabase],
     [polygonTokenTransferHistory],
     aggregators,
     stakingModules,
@@ -128,6 +118,7 @@ async function main() {
 }
 
 /**
+ * Not currently used but kept for future use of BlocksDBs
  * Handles graceful shutdown of the application
  * Ensures all database connections are closed
  * and pending operations are complete

--- a/src/datasources/persistent/TransactionReceiptsDatabase.ts
+++ b/src/datasources/persistent/TransactionReceiptsDatabase.ts
@@ -1,4 +1,4 @@
-import { Hash, TransactionReceipt } from "viem";
+import { Hash, PublicClient, TransactionReceipt } from "viem";
 import { BaseDatabase } from "./BaseDatabase";
 import { Level } from "level";
 import { createRpcClient } from "../../helpers";
@@ -18,9 +18,16 @@ export abstract class BaseTransactionReceiptsDatabase extends BaseDatabase<
  * Addresses in the receipts are NOT checksummed.
  */
 export class TransactionReceiptsDatabase extends BaseTransactionReceiptsDatabase {
-  readonly DB_NAME = `db/${this.chain}/transactionReceipts`;
-  private readonly _db = new Level(this.DB_NAME, { valueEncoding: "json" });
-  private readonly _client = createRpcClient(this.chain);
+  readonly DB_NAME: string;
+  private readonly _db: Level<string, string>;
+  public client: PublicClient;
+
+  constructor(readonly chain: ChainId, client?: PublicClient) {
+    super(chain);
+    this.DB_NAME = `db/${this.chain}/transactionReceipts`;
+    this._db = new Level(this.DB_NAME, { valueEncoding: "json" });
+    this.client = client || createRpcClient(this.chain);
+  }
 
   protected getFromStore(key: string): Promise<string> {
     return this._db.get(key);
@@ -29,6 +36,6 @@ export class TransactionReceiptsDatabase extends BaseTransactionReceiptsDatabase
     return this._db.put(key, val);
   }
   protected fetchData(txHash: Hash): Promise<TransactionReceipt> {
-    return this._client.getTransactionReceipt({ hash: txHash });
+    return this.client.getTransactionReceipt({ hash: txHash });
   }
 }

--- a/src/test/StakerIncentivesCalculatorFork.test.ts
+++ b/src/test/StakerIncentivesCalculatorFork.test.ts
@@ -311,10 +311,6 @@ describe("StakerIncentivesCalculatorForkTest", () => {
     await testClient.mine({ blocks: 1 });
 
     // calculator constructor args
-    const polygonBlocksDatabase = new BlocksDatabase(
-      ChainId.Polygon,
-      testClient.extend(publicActions)
-    );
     const tokenTransferHistory = new TokenTransferHistory(
       config.telToken[ChainId.Polygon],
       startBlock,
@@ -359,7 +355,6 @@ describe("StakerIncentivesCalculatorForkTest", () => {
 
     // instantiate new calculator with localhost rpc and mock constructor args
     const forkedCalculator = new StakerIncentivesCalculator(
-      [polygonBlocksDatabase],
       [tokenTransferHistory],
       [aggregator],
       [stakingModule],

--- a/staker_incentives.json
+++ b/staker_incentives.json
@@ -3,73 +3,89 @@
     {
       "network": "polygon",
       "startBlock": "68093124",
-      "endBlock": "68318774"
+      "endBlock": "68374032"
     }
   ],
   "stakerIncentives": [
     {
       "address": "0xAcF543A44c24aAdF47B50e5cc05c628f3F2A5046",
-      "incentive": "5038958"
+      "incentive": "6719988"
+    },
+    {
+      "address": "0xE3060D70A15f2EdFb390D66e60467Da6F5ECA1C7",
+      "incentive": "139247"
     },
     {
       "address": "0x426d787930A93314048488c4D10946FCeD265Cc7",
-      "incentive": "18186034"
+      "incentive": "6999416"
     },
     {
       "address": "0x096454fa85d4bD21CBB9134966c417f2e40C288C",
-      "incentive": "6062011"
+      "incentive": "2333138"
     },
     {
       "address": "0xaE8f06402E8e67023b13f2F132Dc34422aFA6189",
-      "incentive": "3851"
-    },
-    {
-      "address": "0xb91406Ea49418Ff04F73231BA48930278bCef631",
-      "incentive": "713177"
+      "incentive": "1482"
     },
     {
       "address": "0xc1c106e16cF229be127C30406c598b07986c06BA",
-      "incentive": "10969816"
+      "incentive": "4222047"
     },
     {
       "address": "0x5B74F5c8A2C00fea77cAED166Eb4F71BCe7d38bC",
-      "incentive": "143134"
+      "incentive": "55089"
     },
     {
       "address": "0xe05DDFB83A8b66Df42f06BfB5517Fb5d6857a8ce",
-      "incentive": "1426355"
+      "incentive": "1617386"
     },
     {
       "address": "0x16CaEA275D4F7cF454537b121915D92Bc5CB8C16",
-      "incentive": "3334106"
+      "incentive": "1283226"
     },
     {
       "address": "0x7308fC774925316052AD22Fbdc21f2a7FF4bDA49",
-      "incentive": "7203096"
+      "incentive": "6896483"
     },
     {
       "address": "0x721D683cBd00c78Eb2676fBA03e8c03FDF07f5dC",
-      "incentive": "10697667"
+      "incentive": "4117303"
     },
     {
       "address": "0x82983a034CD8811b62fbdEcDEb300b46947fCC45",
-      "incentive": "1782944"
+      "incentive": "2099824"
+    },
+    {
+      "address": "0xff9aE836c989360f013A4d2F184b5f7e59aD6C11",
+      "incentive": "357739"
+    },
+    {
+      "address": "0xC090D9F71184D03568485a351456C570ff9F9Cbf",
+      "incentive": "80918"
+    },
+    {
+      "address": "0xFb55bcB2E843Cc2dA95c48273eA89F167Faf7b93",
+      "incentive": "20586518"
+    },
+    {
+      "address": "0xb26C7c04A98eb3b92a2688ee8Fc1dA17054eF909",
+      "incentive": "706666"
     },
     {
       "address": "0xdFdf143A6a12185023e01ddC61092Ac97eCB6c05",
-      "incentive": "1782944"
+      "incentive": "686217"
     },
     {
       "address": "0x0603709F92A47D5367Cc93f5b587A29fA286ADbB",
-      "incentive": "12514844"
+      "incentive": "5091183"
     },
     {
       "address": "0xb8e441ad9cA68bf92Da52A40BFBb03Bc6454ABB4",
-      "incentive": "55271282"
+      "incentive": "21272735"
     },
     {
       "address": "0x9B73f16958aD4dF607E8B58aA2f407d66e9FA543",
-      "incentive": "178294"
+      "incentive": "68621"
     },
     {
       "address": "0x681ee9C08368ED5e30519f146cF3A27b24471Dc6",
@@ -81,7 +97,7 @@
     },
     {
       "address": "0xe2e039dD3206870FE6Ad4B88DDf74730c355B2e5",
-      "incentive": "392247"
+      "incentive": "150967"
     },
     {
       "address": "0x6BF81D0d4f4e606C3cB09C45f6FA29f8743c72DE",
@@ -89,67 +105,63 @@
     },
     {
       "address": "0x74c0d21e8ffC5b83dce1A0BB6abCD061D071E85a",
-      "incentive": "5038958"
-    },
-    {
-      "address": "0xE3060D70A15f2EdFb390D66e60467Da6F5ECA1C7",
-      "incentive": "361795"
+      "incentive": "6719988"
     },
     {
       "address": "0xD7Be7655070f986B3E311EE04cc9aa87Cd11ab5d",
-      "incentive": "361795"
+      "incentive": "139247"
     },
     {
       "address": "0xe5C5B9C648a3e66A2A7b8a3f2dA48e76e8309A2C",
-      "incentive": "356588"
+      "incentive": "137243"
     },
     {
       "address": "0x262ba7354bA2946de8f90dCe06883FaFebB6f043",
-      "incentive": "14263556"
+      "incentive": "21904055"
     },
     {
       "address": "0x4DF1C6c7973f4E6e3B22149f7b8eFc4389f97C56",
-      "incentive": "14263556"
-    },
-    {
-      "address": "0x4B3D17974c2F79fEf5D495F082e9eC7d1FD95a06",
-      "incentive": "6062011"
+      "incentive": "10924579"
     },
     {
       "address": "0x3d1F678EBd71CA033f21D6B1B5B0781a66537447",
-      "incentive": "3815501"
+      "incentive": "1468504"
     },
     {
       "address": "0xB6e85e12331BdEA6fF03b25d3dE68a892C99C5D4",
-      "incentive": "891472"
+      "incentive": "343108"
     },
     {
       "address": "0xE2D8A9f98072298241651a1c899907892860A1f5",
       "incentive": "100000"
     },
     {
+      "address": "0xb91406Ea49418Ff04F73231BA48930278bCef631",
+      "incentive": "274486"
+    },
+    {
       "address": "0x040f62A18EB5D5ca87A08E41A22D004ee7A26380",
-      "incentive": "891472"
+      "incentive": "343108"
     },
     {
       "address": "0x18fc6c299B7aA35C8f59537b4b67c23D93E782ea",
-      "incentive": "47069"
+      "incentive": "4178843"
     },
     {
       "address": "0x5C9A07e59Bdc264d0579530b4e08338122833942",
-      "incentive": "2317827"
+      "incentive": "1441056"
     },
     {
       "address": "0x4994A7059A2921398780818c203F83613A9Bf743",
-      "incentive": "17829446"
+      "incentive": "6862172"
     },
     {
       "address": "0xe9052daAC8667a27B38369aD37BEE63A8CD80Fc7",
-      "incentive": "143134"
+      "incentive": "55089"
     },
     {
       "address": "0x8f437d47c7723C7AB5ab896D59549D547181BecB",
-      "incentive": "17374082"
+      "incentive": "6686912"
     },
     {
       "address": "0xA742150Bb2b4e5DfCC4E6df0E577237Fceb797b2",
@@ -157,15 +169,15 @@
     },
     {
       "address": "0x9D89f9451C4B7e04bd58616dbC72e924088AFF21",
-      "incentive": "2496122"
+      "incentive": "13443078"
     },
     {
       "address": "0x94B72396b6B40e19C2a04c28c8aE93dE08b12733",
-      "incentive": "1108064"
+      "incentive": "4086616"
     },
     {
       "address": "0x4CaFc8E23616346de04DE62174B1e615D8E80c70",
-      "incentive": "8277926"
+      "incentive": "7310162"
     },
     {
       "address": "0x6f9A5457e35FF98FCcA68b71c2D1bf7aAAeB714E",
@@ -173,23 +185,107 @@
     },
     {
       "address": "0x0b3d82e9b1D9163a1fe71DC2bc60C6Fb7fb13863",
-      "incentive": "487671"
+      "incentive": "187694"
     },
     {
       "address": "0xb12042f547d28da37E88d7Db7A2CBAaf8CD88F68",
-      "incentive": "1782944"
+      "incentive": "686217"
     },
     {
       "address": "0xDF6F220E72A6320E87576c5075899Be34212f97D",
-      "incentive": "145060"
+      "incentive": "55830"
     },
     {
       "address": "0x3E3309ab5312f6875b6e9bE672b9A43EFb70D760",
-      "incentive": "8914723"
+      "incentive": "6175955"
     },
     {
       "address": "0x47502539673c93B2ACDC9059B36360f76D3548BB",
-      "incentive": "2496122"
+      "incentive": "1015080"
+    },
+    {
+      "address": "0x0254704C23C4765496894a632ef28d6be4DCB259",
+      "incentive": "9263933"
+    },
+    {
+      "address": "0x2EeCd56c9A00E81a393Fd24F22a07C9D80336E20",
+      "incentive": "1848367"
+    },
+    {
+      "address": "0x2abf42F330c60491E8A36B73c9F3F9Ed40CDa546",
+      "incentive": "5009386"
+    },
+    {
+      "address": "0x66B6221845b9bd7A029BCCb5523168a5AcE1e013",
+      "incentive": "28450568"
+    },
+    {
+      "address": "0x331B6287b04a4Bb359C75D102a2104561BB84fe3",
+      "incentive": "41173"
+    },
+    {
+      "address": "0x2A1Cc6c77782EA6BE6C08d61430A79E31Ea4efDf",
+      "incentive": "665630"
+    },
+    {
+      "address": "0x417eD74e3904f2C2d2eBb4e8050bD772374bd82a",
+      "incentive": "89208"
+    },
+    {
+      "address": "0x746F83FF7eAdA9d0fB03DbAbcAF2600ee513DCDB",
+      "incentive": "5765872"
+    },
+    {
+      "address": "0x733e103A702EACEa3189361a3b79902491FBACd1",
+      "incentive": "137243"
+    },
+    {
+      "address": "0xE17Aa7A67B0834823F56f01260b1E0965f14Eb4c",
+      "incentive": "6862172"
+    },
+    {
+      "address": "0x9C4e5edC6A735e4AB68ef04497b64008A955A1A5",
+      "incentive": "553475"
+    },
+    {
+      "address": "0x7011467e458B4cEEED928bac3E178Ce7EB892F2d",
+      "incentive": "2744869"
+    },
+    {
+      "address": "0x469E40f0854EC0E8FaC1Afd4Af2DFfD5aE5569B0",
+      "incentive": "109794"
+    },
+    {
+      "address": "0x21a18db5749f090BB96DE151de4136866cdAC8DF",
+      "incentive": "80918"
+    },
+    {
+      "address": "0x3010A4E7ce5c99208900c218d0375bfEfE7De269",
+      "incentive": "20586518"
+    },
+    {
+      "address": "0x430cB4360cE341a6Ad0Dfa18b9aD1Ae2cFa9AD18",
+      "incentive": "1372434"
+    },
+    {
+      "address": "0x8fa6e6dB6B86d0Cad2fa8DeEb737BC1cB97a2bE1",
+      "incentive": "686217"
+    },
+    {
+      "address": "0x8364044ee8062F0F6C9835f7dfC26da4CE433BB8",
+      "incentive": "686217"
+    },
+    {
+      "address": "0x9fF7d51Cf6a3A12F2Cdd36035827037a35A4B139",
+      "incentive": "23441"
+    },
+    {
+      "address": "0x8060070C9811bdbAeA20fd829033CFC77b498d99",
+      "incentive": "1990030"
+    },
+    {
+      "address": "0x8B66c0aEEc3a231F6e3302dBb7d351B5c7B094B0",
+      "incentive": "274486"
     }
   ]
 }


### PR DESCRIPTION
 Stripped out the BlocksDatabase and replaced it with executor TX fetching. This cuts runtime from 5-10hr to ~1 min (lol) and resolves strange non-deterministic behavior across machines.
 
 - Enormous performance improvement 🥇 
 - Tests passing 💯 
 - Deterministic output 🔢 
 
 Future use of the BlocksDB will need to examine its propensity for race conditions