### PR TITLE
Tenderly simulation passes but execution runs out of gas

### DIFF
--- a/backend/safeTxArrayBuilder.ts
+++ b/backend/safeTxArrayBuilder.ts
@@ -76,7 +76,7 @@ async function main() {
     });
 
     // write Safe TX info as chunks to gitignored `temp` directory, creating if it doesn't exist
-    const chunkSize = 350;
+    const chunkSize = 300;
     const chunks = chunkIssuanceRewardArray(issuanceRewards, chunkSize);
     for (let i = 0; i < chunks.length; i++) {
       const outputDir = path.join(__dirname, "temp");


### PR DESCRIPTION
Tenderly simulation passes but execution runs out of gas for 350 reward entries

Lower to 300 to be sure of sufficient gas