### PR TITLE
fix(telx): clamp tick bounds once at sub-period start to stop fee-growth inflation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 yarn-error.log
 dist
 cache
+backend/rpc_cache
 out
 temp
 .DS_Store

--- a/backend/calculators/TELxRewardsCalculator.ts
+++ b/backend/calculators/TELxRewardsCalculator.ts
@@ -173,7 +173,7 @@ export const POOLS = [BASE_ETH_TEL, POLYGON_ETH_TEL, POLYGON_USDC_EMXN];
  * to refer to the initialization period from pool creation to first period start.
  */
 export const PERIODS = Array.from({ length: 45 }, (_, i) => i);
-const NETWORKS = {
+export const NETWORKS = {
   [ChainId.Polygon]: {
     poolManager: getAddress("0x67366782805870060151383f4bbff9dab53e5cd6"),
     positionRegistry: getAddress("0x2c33fC9c09CfAC5431e754b8fe708B1dA3F5B954"),
@@ -425,7 +425,7 @@ async function updateFeesAndPositions(
   return { lpData, finalPositions };
 }
 
-async function updatePositions(
+export async function updatePositions(
   poolId: `0x${string}`,
   startBlock: bigint,
   endBlock: bigint,
@@ -771,28 +771,48 @@ async function processFees(
       // check the "isSubscribed" flag at start of sub-period
       const isEligibleForRewards = prevChange.isSubscribed;
 
-      // get fee growth values and calculate the subperiod delta
-      const [feeGrowthStart, feeGrowthEnd] = await Promise.all([
-        getFeeGrowthInsideOffchain(
-          client,
-          poolId,
-          stateView,
-          position.tickLower,
-          position.tickUpper,
-          tickSpacing,
-          prevChange.blockNumber, // Fee growth at the start of the sub-period
-        ),
-        getFeeGrowthInsideOffchain(
-          // The new, safe function
-          client,
-          poolId,
-          stateView,
-          position.tickLower,
-          position.tickUpper,
-          tickSpacing,
-          currChange.blockNumber, // Fee growth at the end of the sub-period
-        ),
-      ]);
+      // get fee growth values and calculate the subperiod delta.
+      //
+      // FIX (period-44 fee-inflation): clamp the tick bounds ONCE at the
+      // sub-period START block - where the position's boundary ticks are still
+      // initialized - and reuse those stable bounds at both endpoints. This
+      // prevents a mid-sub-period tick de-initialization from snapping the
+      // bound search to an unrelated tick and reconstructing a phantom
+      // feeGrowthInside (~9e31) that the underflow guard would then credit.
+      let feeGrowthStart = {
+        feeGrowthInside0X128: 0n,
+        feeGrowthInside1X128: 0n,
+      };
+      let feeGrowthEnd = { feeGrowthInside0X128: 0n, feeGrowthInside1X128: 0n };
+      const [clLower, clUpper] = await clampTicksToInitialized(
+        client,
+        poolId,
+        stateView,
+        position.tickLower,
+        position.tickUpper,
+        tickSpacing,
+        prevChange.blockNumber, // clamp at the START block, reused for both
+      );
+      if (clLower !== null && clUpper !== null && clLower < clUpper) {
+        [feeGrowthStart, feeGrowthEnd] = await Promise.all([
+          getFeeGrowthInsideOffchainAtBounds(
+            client,
+            poolId,
+            stateView,
+            clLower,
+            clUpper,
+            prevChange.blockNumber, // start of the sub-period
+          ),
+          getFeeGrowthInsideOffchainAtBounds(
+            client,
+            poolId,
+            stateView,
+            clLower,
+            clUpper,
+            currChange.blockNumber, // end of the sub-period, SAME bounds
+          ),
+        ]);
+      }
 
       // calculate subperiod's fees and add to period total for this position
       const { token0Fees: feesEarned0, token1Fees: feesEarned1 } =
@@ -851,7 +871,7 @@ async function processFees(
 }
 
 // calculates fees earned for the given `liquidity` between start and end checkpoints
-function calculateFees(
+export function calculateFees(
   liquidity: bigint,
   feeGrowthInside0End: bigint,
   feeGrowthInside1End: bigint,
@@ -961,7 +981,7 @@ function modifyLPData(
  * Then calls v4 StateView to fetch fee growth outside using safe initialized tick range
  * To derive the fee growth inside the range in line with onchain Solidity derivation
  */
-async function getFeeGrowthInsideOffchain(
+export async function getFeeGrowthInsideOffchain(
   client: PublicClient,
   poolId: `0x${string}`,
   stateView: Address,
@@ -1077,7 +1097,240 @@ function parseTickInfo(tickInfo: readonly [bigint, bigint, bigint, bigint]): {
 }
 
 /**
+ * Decompose a tick into its [wordPosition, bitPosition] in the v4 tick bitmap,
+ * using the same compression math as `tickToWord`.
+ */
+function tickToWordAndBit(tick: number, tickSpacing: number): [number, number] {
+  let compressed = Math.floor(tick / tickSpacing);
+  if (tick < 0 && tick % tickSpacing !== 0) compressed -= 1;
+  return [compressed >> 8, compressed & 255];
+}
+
+/**
+ * Searches UPWARD from `tickLower` (inclusive) for the first initialized tick
+ * that lies WITHIN the position's declared range [tickLower, tickUpper].
+ * Returns null if no initialized tick exists in range.
+ *
+ * Unlike `findInitializedTickUnder`, this search is strictly bounded by the
+ * position's own range, so it can never snap to a tick outside [tickLower, tickUpper].
+ */
+async function findInitializedTickForward(
+  client: PublicClient,
+  poolId: `0x${string}`,
+  stateView: Address,
+  tickLower: number,
+  tickUpper: number,
+  tickSpacing: number,
+  blockNumber: bigint,
+): Promise<number | null> {
+  const [startWord, startBit] = tickToWordAndBit(tickLower, tickSpacing);
+  const [endWord, endBit] = tickToWordAndBit(tickUpper, tickSpacing);
+
+  for (let word = startWord; word <= endWord; word++) {
+    const bitmap = await getTickBitmap(
+      client,
+      poolId,
+      stateView,
+      word,
+      blockNumber,
+    );
+    if (bitmap !== 0n) {
+      const beginBit = word === startWord ? startBit : 0;
+      const stopBit = word === endWord ? endBit : 255;
+      for (let i = beginBit; i <= stopBit; i++) {
+        if ((bitmap & (1n << BigInt(i))) !== 0n) {
+          return (word * 256 + i) * tickSpacing;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Searches DOWNWARD from `tickUpper` (inclusive) for the first initialized tick
+ * that lies WITHIN the position's declared range [tickLower, tickUpper].
+ * Returns null if no initialized tick exists in range.
+ */
+async function findInitializedTickBackward(
+  client: PublicClient,
+  poolId: `0x${string}`,
+  stateView: Address,
+  tickLower: number,
+  tickUpper: number,
+  tickSpacing: number,
+  blockNumber: bigint,
+): Promise<number | null> {
+  const [startWord, startBit] = tickToWordAndBit(tickLower, tickSpacing);
+  const [endWord, endBit] = tickToWordAndBit(tickUpper, tickSpacing);
+
+  for (let word = endWord; word >= startWord; word--) {
+    const bitmap = await getTickBitmap(
+      client,
+      poolId,
+      stateView,
+      word,
+      blockNumber,
+    );
+    if (bitmap !== 0n) {
+      const topBit = word === endWord ? endBit : 255;
+      const bottomBit = word === startWord ? startBit : 0;
+      for (let i = topBit; i >= bottomBit; i--) {
+        if ((bitmap & (1n << BigInt(i))) !== 0n) {
+          return (word * 256 + i) * tickSpacing;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Computes a STABLE [clLower, clUpper] pair of initialized ticks within the
+ * position's declared range, evaluated ONCE at the sub-period START block.
+ *
+ * Reusing this pair at both the start and end fee-growth queries is the core of
+ * the period-44 fee-inflation fix: it prevents a tick de-initialization that
+ * occurs mid-sub-period from shifting the basis of the fee-growth delta. The
+ * legacy `getFeeGrowthInsideOffchain` recomputed the bounds independently at
+ * each endpoint, so a de-initialized boundary tick would snap the search to an
+ * unrelated tick and reconstruct a phantom feeGrowthInside.
+ */
+export async function clampTicksToInitialized(
+  client: PublicClient,
+  poolId: `0x${string}`,
+  stateView: Address,
+  tickLower: number,
+  tickUpper: number,
+  tickSpacing: number,
+  startBlock: bigint,
+): Promise<[number | null, number | null]> {
+  const clLower = await findInitializedTickForward(
+    client,
+    poolId,
+    stateView,
+    tickLower,
+    tickUpper,
+    tickSpacing,
+    startBlock,
+  );
+  const clUpper = await findInitializedTickBackward(
+    client,
+    poolId,
+    stateView,
+    tickLower,
+    tickUpper,
+    tickSpacing,
+    startBlock,
+  );
+  // no initialized tick in range (or only one) => position earns nothing this sub-period
+  if (clLower === null || clUpper === null || clLower > clUpper) {
+    return [null, null];
+  }
+  return [clLower, clUpper];
+}
+
+/**
+ * Reconstructs feeGrowthInside using EXPLICIT, pre-clamped tick bounds (computed
+ * once at the sub-period start by `clampTicksToInitialized`). The bounds are NOT
+ * recomputed here, so a tick that de-initializes mid-sub-period cannot snap the
+ * search to an unrelated tick.
+ *
+ * Hardening: if either clamped tick has de-initialized by `blockNumber`, the
+ * position had no active liquidity at that boundary, so it earns nothing for the
+ * sub-period and {0, 0} is returned rather than proceeding with stale tick data.
+ */
+export async function getFeeGrowthInsideOffchainAtBounds(
+  client: PublicClient,
+  poolId: `0x${string}`,
+  stateView: Address,
+  clLower: number,
+  clUpper: number,
+  blockNumber: bigint,
+): Promise<{ feeGrowthInside0X128: bigint; feeGrowthInside1X128: bigint }> {
+  // verify both clamped ticks are still initialized at the query block
+  const [lowerTickInfoResult, upperTickInfoResult] = await Promise.all([
+    client.readContract({
+      address: stateView,
+      abi: STATE_VIEW_ABI,
+      functionName: "getTickInfo",
+      args: [poolId, clLower],
+      blockNumber,
+    }),
+    client.readContract({
+      address: stateView,
+      abi: STATE_VIEW_ABI,
+      functionName: "getTickInfo",
+      args: [poolId, clUpper],
+      blockNumber,
+    }),
+  ]);
+  const lowerInitialized =
+    lowerTickInfoResult[0] !== 0n || lowerTickInfoResult[1] !== 0n;
+  const upperInitialized =
+    upperTickInfoResult[0] !== 0n || upperTickInfoResult[1] !== 0n;
+  if (!lowerInitialized || !upperInitialized) {
+    return { feeGrowthInside0X128: 0n, feeGrowthInside1X128: 0n };
+  }
+
+  const [, currentTick] = await client.readContract({
+    address: stateView,
+    abi: STATE_VIEW_ABI,
+    functionName: "getSlot0",
+    args: [poolId],
+    blockNumber,
+  });
+  const [feeGrowthGlobal0X128, feeGrowthGlobal1X128] =
+    await client.readContract({
+      address: stateView,
+      abi: STATE_VIEW_ABI,
+      functionName: "getFeeGrowthGlobals",
+      args: [poolId],
+      blockNumber,
+    });
+
+  const lowerTickInfo = parseTickInfo(lowerTickInfoResult);
+  const upperTickInfo = parseTickInfo(upperTickInfoResult);
+
+  // replicate getFeeGrowthInside on-chain logic, anchored to the clamped bounds
+  let feeGrowthBelow0X128: bigint;
+  let feeGrowthBelow1X128: bigint;
+  if (currentTick >= clLower) {
+    feeGrowthBelow0X128 = lowerTickInfo.feeGrowthOutside0X128;
+    feeGrowthBelow1X128 = lowerTickInfo.feeGrowthOutside1X128;
+  } else {
+    feeGrowthBelow0X128 =
+      feeGrowthGlobal0X128 - lowerTickInfo.feeGrowthOutside0X128;
+    feeGrowthBelow1X128 =
+      feeGrowthGlobal1X128 - lowerTickInfo.feeGrowthOutside1X128;
+  }
+
+  let feeGrowthAbove0X128: bigint;
+  let feeGrowthAbove1X128: bigint;
+  if (currentTick < clUpper) {
+    feeGrowthAbove0X128 = upperTickInfo.feeGrowthOutside0X128;
+    feeGrowthAbove1X128 = upperTickInfo.feeGrowthOutside1X128;
+  } else {
+    feeGrowthAbove0X128 =
+      feeGrowthGlobal0X128 - upperTickInfo.feeGrowthOutside0X128;
+    feeGrowthAbove1X128 =
+      feeGrowthGlobal1X128 - upperTickInfo.feeGrowthOutside1X128;
+  }
+
+  const feeGrowthInside0X128 =
+    feeGrowthGlobal0X128 - feeGrowthBelow0X128 - feeGrowthAbove0X128;
+  const feeGrowthInside1X128 =
+    feeGrowthGlobal1X128 - feeGrowthBelow1X128 - feeGrowthAbove1X128;
+
+  return { feeGrowthInside0X128, feeGrowthInside1X128 };
+}
+
+/**
  * Finds the highest safe initialized tick under `startTick` by searching downward (inclusive)
+ *
+ * @deprecated Retained only for the `inspectSwaps` diagnostic. The sub-period
+ * fee-growth path now uses `clampTicksToInitialized` +
+ * `getFeeGrowthInsideOffchainAtBounds`, which fix the de-initialization snap bug.
  */
 async function findInitializedTickUnder(
   client: PublicClient,

--- a/backend/sim/README.md
+++ b/backend/sim/README.md
@@ -1,0 +1,56 @@
+# TELx fee-growth de-initialization fix - validation scripts
+
+These scripts validate the fix in `backend/calculators/TELxRewardsCalculator.ts`
+for the period-44 fee-inflation defect.
+
+## The defect (now fixed)
+
+`getFeeGrowthInsideOffchain` rebuilt a position's fee growth by re-locating its
+initialized boundary ticks **independently at each sub-period endpoint**. When a
+narrow position's boundary ticks de-initialize after the price leaves its range,
+`findInitializedTickUnder` snaps to unrelated ticks and reconstructs a phantom
+`feeGrowthInside` (~9e31). The underflow guard in `calculateFees`
+(`end >= start ? delta : 0`) then credits that phantom as real fees.
+
+## The fix
+
+`clampTicksToInitialized` computes the initialized tick bounds **once, at the
+sub-period start block** (where the position's ticks are still initialized), and
+`getFeeGrowthInsideOffchainAtBounds` reuses those exact bounds at both endpoints.
+If either clamped tick has de-initialized by the query block, the sub-period
+earns nothing. Genuine positions are unaffected.
+
+## Scripts
+
+All read the RPC URL from `POLYGON_RPC_URL` (`.env`); none contain secrets.
+
+- `onchainRepro.ts` - reproduces the report's worked example (token 110585)
+  against real Polygon archive state using the production code path. Compares the
+  buggy reconstruction, the canonical `StateView.getFeeGrowthInside`, and the fix.
+  Result: buggy credits exactly 65,099,934 (raw); canonical and fix return 0.
+  Run: `npx ts-node backend/sim/onchainRepro.ts`
+
+- `offlineMechanism.ts` - deterministic, no-network reproduction with an
+  in-memory tick-state mock. Reproduces the same phantom offline and demonstrates
+  the guard's bi-directional failure (over-credit when the phantom lands on the
+  end, silent zeroing when it lands on the start).
+  Run: `npx ts-node backend/sim/offlineMechanism.ts`
+
+- `rerunPeriod44.ts` - drives the production `updatePositions` + fee-credit loop
+  over the real period-44 Polygon range, both ways, and reports per-position and
+  pool-level credited fees. Caches RPC reads to `backend/rpc_cache` (gitignored).
+  NOTE: this harness starts from an empty position set rather than the period-43
+  checkpoint, so it captures every event-active (phantom) position but understates
+  silent pre-period passive positions. It is a convenience reproduction; the
+  authoritative re-run is the calculator CLI below.
+  Run: `npx ts-node backend/sim/rerunPeriod44.ts`
+
+## Authoritative re-run
+
+On `master` the full period-44 config and checkpoint chain exist, so the fix can
+be validated end-to-end by resuming from the period-43 checkpoint and comparing
+the regenerated period-44 output against the committed (buggy) `*-44.json`:
+
+```
+yarn ts-node backend/calculators/TELxRewardsCalculator.ts 0x25412ca33f9a2069f0520708da3f70a7843374dd46dc1c7e62f6d5002f5f9fa7:44
+```

--- a/backend/sim/offlineMechanism.ts
+++ b/backend/sim/offlineMechanism.ts
@@ -1,0 +1,272 @@
+/**
+ * Offline, deterministic reproduction of the fee-inflation mechanism.
+ *
+ * No network required. A tiny in-memory "StateView" mock serves the same
+ * shape the production code reads (slot0 / globals / tickBitmap / tickInfo),
+ * and the VERBATIM production functions run against it. This:
+ *
+ *   - reproduces the exact 65,099,934 phantom credit offline (Scenario A), and
+ *   - demonstrates the GUARD's bi-directional failure (Scenario B): the same
+ *     phantom value over-credits when it lands on the period END, and zeroes a
+ *     real reward when it lands on the period START.
+ *
+ * Run: npx ts-node backend/sim/offlineMechanism.ts
+ */
+
+const TICK_SPACING = 60;
+const Q128 = 2n ** 128n;
+const TWO256 = 2n ** 256n;
+const POOL = "0xpool" as `0x${string}`;
+const SV = "0xsv" as `0x${string}`;
+
+// --- in-memory chain state, keyed by block ---
+interface TickInfo {
+  liquidityGross: bigint;
+  liquidityNet: bigint;
+  fo0: bigint;
+  fo1: bigint;
+}
+interface Snapshot {
+  currentTick: number;
+  global0: bigint;
+  global1: bigint;
+  ticks: Map<number, TickInfo>; // ONLY initialized ticks present
+}
+const SNAPSHOTS = new Map<bigint, Snapshot>();
+
+// build per-word bitmaps from the set of initialized ticks, using the EXACT
+// bit math the production findInitializedTickUnder/tickToWord rely on.
+function wordAndBit(tick: number): [number, number] {
+  let compressed = Math.floor(tick / TICK_SPACING);
+  if (tick < 0 && tick % TICK_SPACING !== 0) compressed -= 1;
+  return [compressed >> 8, compressed & 255];
+}
+function bitmapForWord(snap: Snapshot, word: number): bigint {
+  let bm = 0n;
+  for (const t of snap.ticks.keys()) {
+    const [w, b] = wordAndBit(t);
+    if (w === word) bm |= 1n << BigInt(b);
+  }
+  return bm;
+}
+
+// minimal mock matching viem's client.readContract surface used by the code
+const mockClient: any = {
+  async readContract(p: any) {
+    const snap = SNAPSHOTS.get(p.blockNumber as bigint)!;
+    switch (p.functionName) {
+      case "getSlot0":
+        return [0n, snap.currentTick, 0, 0];
+      case "getFeeGrowthGlobals":
+        return [snap.global0, snap.global1];
+      case "getTickBitmap":
+        return bitmapForWord(snap, Number(p.args[1]));
+      case "getTickInfo": {
+        const ti = snap.ticks.get(Number(p.args[1]));
+        return ti
+          ? [ti.liquidityGross, ti.liquidityNet, ti.fo0, ti.fo1]
+          : [0n, 0n, 0n, 0n];
+      }
+      default:
+        throw new Error("unexpected call " + p.functionName);
+    }
+  },
+};
+
+// ===========================================================================
+// VERBATIM from backend/calculators/TELxRewardsCalculator.ts
+// ===========================================================================
+function calculateFees(
+  liquidity: bigint,
+  feeGrowthInside0End: bigint,
+  feeGrowthInside1End: bigint,
+  feeGrowthInside0Start: bigint,
+  feeGrowthInside1Start: bigint,
+): { token0Fees: bigint; token1Fees: bigint } {
+  // underflow protection: return 0 if current is less than last.
+  const feeGrowthDelta0 =
+    feeGrowthInside0End >= feeGrowthInside0Start
+      ? feeGrowthInside0End - feeGrowthInside0Start
+      : 0n;
+  const feeGrowthDelta1 =
+    feeGrowthInside1End >= feeGrowthInside1Start
+      ? feeGrowthInside1End - feeGrowthInside1Start
+      : 0n;
+  return {
+    token0Fees: (feeGrowthDelta0 * liquidity) / Q128,
+    token1Fees: (feeGrowthDelta1 * liquidity) / Q128,
+  };
+}
+
+async function getFeeGrowthInsideOffchain(
+  client: any,
+  poolId: `0x${string}`,
+  stateView: any,
+  tickLower: number,
+  tickUpper: number,
+  tickSpacing: number,
+  blockNumber: bigint,
+): Promise<{ feeGrowthInside0X128: bigint; feeGrowthInside1X128: bigint }> {
+  const [, currentTick] = await client.readContract({
+    address: stateView, functionName: "getSlot0", args: [poolId], blockNumber,
+  });
+  const [feeGrowthGlobal0X128, feeGrowthGlobal1X128] = await client.readContract({
+    address: stateView, functionName: "getFeeGrowthGlobals", args: [poolId], blockNumber,
+  });
+  const safeTickLower = await findInitializedTickUnder(client, poolId, stateView, tickLower, tickSpacing, blockNumber);
+  const safeTickUpper = await findInitializedTickUnder(client, poolId, stateView, tickUpper, tickSpacing, blockNumber);
+  if (safeTickLower === null || safeTickUpper === null || safeTickLower >= safeTickUpper) {
+    return { feeGrowthInside0X128: 0n, feeGrowthInside1X128: 0n };
+  }
+  const [lowerTickInfoResult, upperTickInfoResult] = await Promise.all([
+    client.readContract({ address: stateView, functionName: "getTickInfo", args: [poolId, safeTickLower], blockNumber }),
+    client.readContract({ address: stateView, functionName: "getTickInfo", args: [poolId, safeTickUpper], blockNumber }),
+  ]);
+  const lowerTickInfo = parseTickInfo(lowerTickInfoResult);
+  const upperTickInfo = parseTickInfo(upperTickInfoResult);
+  let feeGrowthBelow0X128: bigint, feeGrowthBelow1X128: bigint;
+  if (currentTick >= tickLower) {
+    feeGrowthBelow0X128 = lowerTickInfo.feeGrowthOutside0X128;
+    feeGrowthBelow1X128 = lowerTickInfo.feeGrowthOutside1X128;
+  } else {
+    feeGrowthBelow0X128 = feeGrowthGlobal0X128 - lowerTickInfo.feeGrowthOutside0X128;
+    feeGrowthBelow1X128 = feeGrowthGlobal1X128 - lowerTickInfo.feeGrowthOutside1X128;
+  }
+  let feeGrowthAbove0X128: bigint, feeGrowthAbove1X128: bigint;
+  if (currentTick < tickUpper) {
+    feeGrowthAbove0X128 = upperTickInfo.feeGrowthOutside0X128;
+    feeGrowthAbove1X128 = upperTickInfo.feeGrowthOutside1X128;
+  } else {
+    feeGrowthAbove0X128 = feeGrowthGlobal0X128 - upperTickInfo.feeGrowthOutside0X128;
+    feeGrowthAbove1X128 = feeGrowthGlobal1X128 - upperTickInfo.feeGrowthOutside1X128;
+  }
+  // NB: production does NOT reduce mod 2^256 here; JS bigint keeps the raw
+  // signed result. The on-chain run shows the raw value matches production.
+  const feeGrowthInside0X128 = feeGrowthGlobal0X128 - feeGrowthBelow0X128 - feeGrowthAbove0X128;
+  const feeGrowthInside1X128 = feeGrowthGlobal1X128 - feeGrowthBelow1X128 - feeGrowthAbove1X128;
+  return { feeGrowthInside0X128, feeGrowthInside1X128 };
+}
+
+function parseTickInfo(tickInfo: readonly [bigint, bigint, bigint, bigint]) {
+  return { feeGrowthOutside0X128: tickInfo[2], feeGrowthOutside1X128: tickInfo[3] };
+}
+
+async function findInitializedTickUnder(
+  client: any, poolId: `0x${string}`, stateView: any, startTick: number,
+  tickSpacing: number, blockNumber: bigint, searchLimit: number = 2560,
+): Promise<number | null> {
+  const startWord = tickToWord(startTick, tickSpacing);
+  let startCompressed = Math.floor(startTick / tickSpacing);
+  if (startTick < 0 && startTick % tickSpacing !== 0) startCompressed -= 1;
+  const startBitPos = startCompressed & 255;
+  for (let wordOffset = 0; wordOffset < searchLimit; wordOffset++) {
+    const currentWord = startWord - wordOffset;
+    const bitmap = await getTickBitmap(client, poolId, stateView, currentWord, blockNumber);
+    if (bitmap !== 0n) {
+      const startBit = wordOffset === 0 ? startBitPos : 255;
+      for (let i = startBit; i >= 0; i--) {
+        const initialized = (bitmap & (1n << BigInt(i))) !== 0n;
+        if (initialized) return (currentWord * 256 + i) * tickSpacing;
+      }
+    }
+  }
+  return null;
+}
+
+function tickToWord(tick: number, tickSpacing: number): number {
+  let compressed = Math.floor(tick / tickSpacing);
+  if (tick < 0 && tick % tickSpacing !== 0) compressed -= 1;
+  return compressed >> 8;
+}
+
+async function getTickBitmap(client: any, poolId: `0x${string}`, stateView: any, wordPosition: number, blockNumber: bigint): Promise<bigint> {
+  if (wordPosition < -32768 || wordPosition > 32767) throw new Error("Word position out of int16 range");
+  return client.readContract({ address: stateView, functionName: "getTickBitmap", args: [poolId, wordPosition], blockNumber });
+}
+// ===========================================================================
+
+// canonical: getFeeGrowthInside computed from the TRUE position ticks (no snap),
+// in unsigned mod-2^256 arithmetic, exactly like the Solidity view function.
+async function canonical(tickLower: number, tickUpper: number, block: bigint) {
+  const snap = SNAPSHOTS.get(block)!;
+  const lo = snap.ticks.get(tickLower) ?? { fo0: 0n, fo1: 0n } as any;
+  const up = snap.ticks.get(tickUpper) ?? { fo0: 0n, fo1: 0n } as any;
+  const G1 = snap.global1;
+  const below1 = snap.currentTick >= tickLower ? lo.fo1 : G1 - lo.fo1;
+  const above1 = snap.currentTick < tickUpper ? up.fo1 : G1 - up.fo1;
+  const inside1 = ((G1 - below1 - above1) % TWO256 + TWO256) % TWO256;
+  return { feeGrowthInside1X128: inside1 };
+}
+
+const fmt = (x: bigint) => `${x} (~${Number(x < 0n ? -x : x).toExponential(3)})`;
+
+async function scenarioA() {
+  console.log("\n" + "=".repeat(78));
+  console.log("SCENARIO A (offline) - over-credit, mirrors on-chain token 110585");
+  console.log("=".repeat(78));
+  const tickLower = -233880, tickUpper = -233580;
+  const L = 248377324214831n; // real on-chain liquidity for 110585
+  const P = 89188334569806566723323839869630n; // real on-chain phantom feeGrowthInside1
+
+  // START: in range, both boundary ticks initialized; feeGrowthInside == 0
+  SNAPSHOTS.set(1n, {
+    currentTick: -233720, global0: 0n, global1: 1000n,
+    ticks: new Map([
+      [tickLower, { liquidityGross: 1n, liquidityNet: 1n, fo0: 0n, fo1: 600n }],
+      [tickUpper, { liquidityGross: 1n, liquidityNet: 1n, fo0: 0n, fo1: 400n }],
+    ]),
+  });
+  // END: out of range, boundary ticks DE-INITIALIZED; distant snapped ticks carry the phantom
+  SNAPSHOTS.set(2n, {
+    currentTick: -233940, global0: 0n, global1: 2000n,
+    ticks: new Map([
+      [-233940, { liquidityGross: 1n, liquidityNet: 1n, fo0: 0n, fo1: P }], // snap target for lower
+      [-233640, { liquidityGross: 1n, liquidityNet: 1n, fo0: 0n, fo1: 0n }], // snap target for upper
+    ]),
+  });
+
+  const bugStart = await getFeeGrowthInsideOffchain(mockClient, POOL, SV, tickLower, tickUpper, TICK_SPACING, 1n);
+  const bugEnd = await getFeeGrowthInsideOffchain(mockClient, POOL, SV, tickLower, tickUpper, TICK_SPACING, 2n);
+  const canStart = await canonical(tickLower, tickUpper, 1n);
+  const canEnd = await canonical(tickLower, tickUpper, 2n);
+
+  const snapLo = await findInitializedTickUnder(mockClient, POOL, SV, tickLower, TICK_SPACING, 2n);
+  const snapUp = await findInitializedTickUnder(mockClient, POOL, SV, tickUpper, TICK_SPACING, 2n);
+  console.log(`end-block snap: ${tickLower}->${snapLo}, ${tickUpper}->${snapUp}`);
+  console.log(`BUGGY     feeGrowthInside1: start=${bugStart.feeGrowthInside1X128}  end=${fmt(bugEnd.feeGrowthInside1X128)}`);
+  console.log(`CANONICAL feeGrowthInside1: start=${canStart.feeGrowthInside1X128}  end=${canEnd.feeGrowthInside1X128}`);
+  const cBug = calculateFees(L, 0n, bugEnd.feeGrowthInside1X128, 0n, bugStart.feeGrowthInside1X128);
+  const cCan = calculateFees(L, 0n, canEnd.feeGrowthInside1X128, 0n, canStart.feeGrowthInside1X128);
+  console.log(`credited token1Fees:  BUGGY=${cBug.token1Fees}   CANONICAL=${cCan.token1Fees}`);
+  console.log(`=> reproduces 65,099,934 offline: ${cBug.token1Fees === 65099934n ? "YES" : "NO"}`);
+}
+
+function scenarioB() {
+  console.log("\n" + "=".repeat(78));
+  console.log("SCENARIO B - the guard is BI-DIRECTIONAL (same phantom, both orientations)");
+  console.log("=".repeat(78));
+  const L = 248377324214831n;
+  const P = 89188334569806566723323839869630n; // phantom feeGrowthInside1 the snap can produce
+  // a REAL in-range fee-growth delta sized to credit ~50,000 TEL-units (delta1 * L / 2^128)
+  const realGrowth = (50000n * Q128) / L;
+
+  // Orientation 1: phantom lands on END -> end >= start -> full phantom credited
+  const over = calculateFees(L, 0n, P, 0n, 0n);
+  // Orientation 2: phantom lands on START -> end < start -> guard returns 0
+  const under = calculateFees(L, 0n, realGrowth, 0n, P);
+  // Control: same real growth with a clean start -> correct positive credit
+  const correct = calculateFees(L, 0n, realGrowth, 0n, 0n);
+
+  console.log(`phantom-at-END   (start=0,    end=phantom): credited token1Fees = ${over.token1Fees}   <- OVER-credit`);
+  console.log(`phantom-at-START (start=phantom, end=real):  credited token1Fees = ${under.token1Fees}        <- UNDER-credit (real fees ZEROED)`);
+  console.log(`control          (start=0,    end=real):     credited token1Fees = ${correct.token1Fees}   <- what it SHOULD be`);
+  console.log(`=> same guard "${"end >= start ? delta : 0"}" both inflates and silently zeroes, depending on which boundary the snap corrupts.`);
+}
+
+async function main() {
+  console.log("OFFLINE deterministic mechanism reproduction (no RPC)");
+  await scenarioA();
+  scenarioB();
+  console.log();
+}
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/backend/sim/onchainRepro.ts
+++ b/backend/sim/onchainRepro.ts
@@ -1,0 +1,518 @@
+/**
+ * On-chain reproduction harness for the "fee-inflation" report (period 44).
+ *
+ * Goal: independently test the report's claims using the REAL production code
+ * path against REAL Polygon archive state, then compare three computations at
+ * the exact blocks the report cites:
+ *
+ *   (1) BUGGY     - the production getFeeGrowthInsideOffchain + findInitializedTickUnder
+ *                   (copied verbatim from backend/calculators/TELxRewardsCalculator.ts)
+ *   (2) CANONICAL - StateView.getFeeGrowthInside (the on-chain view function)
+ *   (3) FIXED     - the report's proposed clamp-once-at-start approach
+ *
+ * Run: npx ts-node backend/sim/onchainRepro.ts
+ *
+ * NOTE: the functions in the "VERBATIM" block below are copied byte-for-byte
+ * from TELxRewardsCalculator.ts so this harness exercises the exact logic that
+ * runs in production. Diff them against the source to confirm fidelity.
+ */
+import {
+  createPublicClient,
+  http,
+  parseAbi,
+  type Address,
+  type PublicClient,
+} from "viem";
+import { polygon } from "viem/chains";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const RPC = process.env.POLYGON_RPC_URL;
+if (!RPC) throw new Error("POLYGON_RPC_URL not set");
+
+const client = createPublicClient({
+  chain: polygon,
+  transport: http(RPC),
+}) as PublicClient;
+
+// --- polygon-ETH-TEL pool config (from TELxRewardsCalculator.ts) ---
+const POOL_ID =
+  "0x25412ca33f9a2069f0520708da3f70a7843374dd46dc1c7e62f6d5002f5f9fa7" as const;
+const STATE_VIEW = "0x5ea1bd7974c8a611cbab0bdcafcb1d9cc9b3ba5a" as Address;
+const POSITION_MANAGER = "0x1Ec2eBf4F37E7363FDfe3551602425af0B3ceef9" as Address;
+const TICK_SPACING = 60;
+// currency0 = WETH, currency1 = TEL (denominator). credited "TEL" figure = token1Fees.
+
+const STATE_VIEW_ABI = parseAbi([
+  "function getSlot0(bytes32 id) external view returns (uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+  "function getFeeGrowthInside(bytes32 poolId, int24 tickLower, int24 tickUpper) external view returns (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128)",
+  "function getFeeGrowthGlobals(bytes32 poolId) external view returns (uint256 feeGrowthGlobal0, uint256 feeGrowthGlobal1)",
+  "function getTickBitmap(bytes32 poolId, int16 wordPosition) external view returns (uint256)",
+  "function getTickInfo(bytes32 poolId, int24 tick) external view returns (uint128 liquidityGross,int128 liquidityNet,uint256 feeGrowthOutside0X128,uint256 feeGrowthOutside1X128)",
+]);
+const POSITION_MANAGER_ABI = parseAbi([
+  "function getPositionLiquidity(uint256 tokenId) external view returns (uint128 liquidity)",
+]);
+
+// ===========================================================================
+// VERBATIM from backend/calculators/TELxRewardsCalculator.ts (the buggy path)
+// ===========================================================================
+function calculateFees(
+  liquidity: bigint,
+  feeGrowthInside0End: bigint,
+  feeGrowthInside1End: bigint,
+  feeGrowthInside0Start: bigint,
+  feeGrowthInside1Start: bigint,
+): { token0Fees: bigint; token1Fees: bigint } {
+  const Q128 = 2n ** 128n;
+  // underflow protection: return 0 if current is less than last. this also ignores massive fee growth gained by JIT liquidity actions
+  const feeGrowthDelta0 =
+    feeGrowthInside0End >= feeGrowthInside0Start
+      ? feeGrowthInside0End - feeGrowthInside0Start
+      : 0n;
+  const feeGrowthDelta1 =
+    feeGrowthInside1End >= feeGrowthInside1Start
+      ? feeGrowthInside1End - feeGrowthInside1Start
+      : 0n;
+
+  return {
+    token0Fees: (feeGrowthDelta0 * liquidity) / Q128,
+    token1Fees: (feeGrowthDelta1 * liquidity) / Q128,
+  };
+}
+
+async function getFeeGrowthInsideOffchain(
+  client: PublicClient,
+  poolId: `0x${string}`,
+  stateView: Address,
+  tickLower: number,
+  tickUpper: number,
+  tickSpacing: number,
+  blockNumber: bigint,
+): Promise<{ feeGrowthInside0X128: bigint; feeGrowthInside1X128: bigint }> {
+  const [, currentTick] = await client.readContract({
+    address: stateView,
+    abi: STATE_VIEW_ABI,
+    functionName: "getSlot0",
+    args: [poolId],
+    blockNumber,
+  });
+  const [feeGrowthGlobal0X128, feeGrowthGlobal1X128] =
+    await client.readContract({
+      address: stateView,
+      abi: STATE_VIEW_ABI,
+      functionName: "getFeeGrowthGlobals",
+      args: [poolId],
+      blockNumber,
+    });
+
+  // find nearest initialized ticks by searching DOWNWARD for both
+  const safeTickLower = await findInitializedTickUnder(
+    client,
+    poolId,
+    stateView,
+    tickLower,
+    tickSpacing,
+    blockNumber,
+  );
+  const safeTickUpper = await findInitializedTickUnder(
+    client,
+    poolId,
+    stateView,
+    tickUpper,
+    tickSpacing,
+    blockNumber,
+  );
+
+  if (
+    safeTickLower === null ||
+    safeTickUpper === null ||
+    safeTickLower >= safeTickUpper
+  ) {
+    return { feeGrowthInside0X128: 0n, feeGrowthInside1X128: 0n };
+  }
+
+  // replicate getFeeGrowthInside on-chain logic
+  const [lowerTickInfoResult, upperTickInfoResult] = await Promise.all([
+    client.readContract({
+      address: stateView,
+      abi: STATE_VIEW_ABI,
+      functionName: "getTickInfo",
+      args: [poolId, safeTickLower],
+      blockNumber,
+    }),
+    client.readContract({
+      address: stateView,
+      abi: STATE_VIEW_ABI,
+      functionName: "getTickInfo",
+      args: [poolId, safeTickUpper],
+      blockNumber,
+    }),
+  ]);
+
+  const lowerTickInfo = parseTickInfo(lowerTickInfoResult);
+  const upperTickInfo = parseTickInfo(upperTickInfoResult);
+
+  let feeGrowthBelow0X128: bigint;
+  let feeGrowthBelow1X128: bigint;
+  if (currentTick >= tickLower) {
+    feeGrowthBelow0X128 = lowerTickInfo.feeGrowthOutside0X128;
+    feeGrowthBelow1X128 = lowerTickInfo.feeGrowthOutside1X128;
+  } else {
+    feeGrowthBelow0X128 =
+      feeGrowthGlobal0X128 - lowerTickInfo.feeGrowthOutside0X128;
+    feeGrowthBelow1X128 =
+      feeGrowthGlobal1X128 - lowerTickInfo.feeGrowthOutside1X128;
+  }
+
+  let feeGrowthAbove0X128: bigint;
+  let feeGrowthAbove1X128: bigint;
+  if (currentTick < tickUpper) {
+    feeGrowthAbove0X128 = upperTickInfo.feeGrowthOutside0X128;
+    feeGrowthAbove1X128 = upperTickInfo.feeGrowthOutside1X128;
+  } else {
+    feeGrowthAbove0X128 =
+      feeGrowthGlobal0X128 - upperTickInfo.feeGrowthOutside0X128;
+    feeGrowthAbove1X128 =
+      feeGrowthGlobal1X128 - upperTickInfo.feeGrowthOutside1X128;
+  }
+
+  const feeGrowthInside0X128 =
+    feeGrowthGlobal0X128 - feeGrowthBelow0X128 - feeGrowthAbove0X128;
+  const feeGrowthInside1X128 =
+    feeGrowthGlobal1X128 - feeGrowthBelow1X128 - feeGrowthAbove1X128;
+
+  return { feeGrowthInside0X128, feeGrowthInside1X128 };
+}
+
+function parseTickInfo(tickInfo: readonly [bigint, bigint, bigint, bigint]): {
+  feeGrowthOutside0X128: bigint;
+  feeGrowthOutside1X128: bigint;
+} {
+  return {
+    feeGrowthOutside0X128: tickInfo[2],
+    feeGrowthOutside1X128: tickInfo[3],
+  };
+}
+
+async function findInitializedTickUnder(
+  client: PublicClient,
+  poolId: `0x${string}`,
+  stateView: Address,
+  startTick: number,
+  tickSpacing: number,
+  blockNumber: bigint,
+  searchLimit: number = 2560,
+): Promise<number | null> {
+  const startWord = tickToWord(startTick, tickSpacing);
+
+  let startCompressed = Math.floor(startTick / tickSpacing);
+  if (startTick < 0 && startTick % tickSpacing !== 0) {
+    startCompressed -= 1;
+  }
+  const startBitPos = startCompressed & 255;
+
+  for (let wordOffset = 0; wordOffset < searchLimit; wordOffset++) {
+    const currentWord = startWord - wordOffset;
+
+    const bitmap = await getTickBitmap(
+      client,
+      poolId,
+      stateView,
+      currentWord,
+      blockNumber,
+    );
+
+    if (bitmap !== 0n) {
+      const startBit = wordOffset === 0 ? startBitPos : 255;
+
+      for (let i = startBit; i >= 0; i--) {
+        const bit = 1n;
+        const initialized = (bitmap & (bit << BigInt(i))) !== 0n;
+
+        if (initialized) {
+          const tickIndex = (currentWord * 256 + i) * tickSpacing;
+          return tickIndex;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function tickToWord(tick: number, tickSpacing: number): number {
+  let compressed = Math.floor(tick / tickSpacing);
+  if (tick < 0 && tick % tickSpacing !== 0) {
+    compressed -= 1;
+  }
+  return compressed >> 8;
+}
+
+async function getTickBitmap(
+  client: PublicClient,
+  poolId: `0x${string}`,
+  stateView: Address,
+  wordPosition: number,
+  blockNumber: bigint,
+): Promise<bigint> {
+  if (wordPosition < -32768 || wordPosition > 32767) {
+    throw new Error("Word position out of int16 range");
+  }
+
+  return client.readContract({
+    address: stateView,
+    abi: STATE_VIEW_ABI,
+    functionName: "getTickBitmap",
+    args: [poolId, wordPosition],
+    blockNumber: blockNumber,
+  });
+}
+// ===========================================================================
+// END VERBATIM
+// ===========================================================================
+
+// --- (2) CANONICAL: the on-chain view function ---
+async function getFeeGrowthInsideCanonical(
+  tickLower: number,
+  tickUpper: number,
+  blockNumber: bigint,
+): Promise<{ feeGrowthInside0X128: bigint; feeGrowthInside1X128: bigint }> {
+  const [feeGrowthInside0X128, feeGrowthInside1X128] =
+    await client.readContract({
+      address: STATE_VIEW,
+      abi: STATE_VIEW_ABI,
+      functionName: "getFeeGrowthInside",
+      args: [POOL_ID, tickLower, tickUpper],
+      blockNumber,
+    });
+  return { feeGrowthInside0X128, feeGrowthInside1X128 };
+}
+
+// --- (3) FIXED: report's proposed clamp-once-at-start approach ---
+async function tickIsInitialized(
+  tick: number,
+  blockNumber: bigint,
+): Promise<boolean> {
+  const [liquidityGross, liquidityNet] = await client.readContract({
+    address: STATE_VIEW,
+    abi: STATE_VIEW_ABI,
+    functionName: "getTickInfo",
+    args: [POOL_ID, tick],
+    blockNumber,
+  });
+  return liquidityGross !== 0n || liquidityNet !== 0n;
+}
+
+async function findInitializedTickForward(
+  tickLower: number,
+  tickUpper: number,
+  tickSpacing: number,
+  blockNumber: bigint,
+): Promise<number | null> {
+  for (let t = tickLower; t <= tickUpper; t += tickSpacing) {
+    if (await tickIsInitialized(t, blockNumber)) return t;
+  }
+  return null;
+}
+
+async function findInitializedTickBackward(
+  tickLower: number,
+  tickUpper: number,
+  tickSpacing: number,
+  blockNumber: bigint,
+): Promise<number | null> {
+  for (let t = tickUpper; t >= tickLower; t -= tickSpacing) {
+    if (await tickIsInitialized(t, blockNumber)) return t;
+  }
+  return null;
+}
+
+async function clampTicksToInitialized(
+  tickLower: number,
+  tickUpper: number,
+  tickSpacing: number,
+  startBlock: bigint,
+): Promise<[number | null, number | null]> {
+  const clLower = await findInitializedTickForward(
+    tickLower,
+    tickUpper,
+    tickSpacing,
+    startBlock,
+  );
+  const clUpper = await findInitializedTickBackward(
+    tickLower,
+    tickUpper,
+    tickSpacing,
+    startBlock,
+  );
+  if (clLower === null || clUpper === null || clLower > clUpper) {
+    return [null, null];
+  }
+  return [clLower, clUpper];
+}
+
+// reconstruct using EXPLICIT, pre-clamped bounds; verify both still initialized
+async function getFeeGrowthInsideOffchainAtBounds(
+  clLower: number,
+  clUpper: number,
+  blockNumber: bigint,
+): Promise<{ feeGrowthInside0X128: bigint; feeGrowthInside1X128: bigint }> {
+  // hardening: if either clamped tick de-initialized by this block, earn nothing
+  if (
+    !(await tickIsInitialized(clLower, blockNumber)) ||
+    !(await tickIsInitialized(clUpper, blockNumber))
+  ) {
+    return { feeGrowthInside0X128: 0n, feeGrowthInside1X128: 0n };
+  }
+
+  const [, currentTick] = await client.readContract({
+    address: STATE_VIEW,
+    abi: STATE_VIEW_ABI,
+    functionName: "getSlot0",
+    args: [POOL_ID],
+    blockNumber,
+  });
+  const [g0, g1] = await client.readContract({
+    address: STATE_VIEW,
+    abi: STATE_VIEW_ABI,
+    functionName: "getFeeGrowthGlobals",
+    args: [POOL_ID],
+    blockNumber,
+  });
+  const [lower, upper] = await Promise.all([
+    client.readContract({
+      address: STATE_VIEW,
+      abi: STATE_VIEW_ABI,
+      functionName: "getTickInfo",
+      args: [POOL_ID, clLower],
+      blockNumber,
+    }),
+    client.readContract({
+      address: STATE_VIEW,
+      abi: STATE_VIEW_ABI,
+      functionName: "getTickInfo",
+      args: [POOL_ID, clUpper],
+      blockNumber,
+    }),
+  ]);
+  const lo = parseTickInfo(lower);
+  const up = parseTickInfo(upper);
+  const below0 = currentTick >= clLower ? lo.feeGrowthOutside0X128 : g0 - lo.feeGrowthOutside0X128;
+  const below1 = currentTick >= clLower ? lo.feeGrowthOutside1X128 : g1 - lo.feeGrowthOutside1X128;
+  const above0 = currentTick < clUpper ? up.feeGrowthOutside0X128 : g0 - up.feeGrowthOutside0X128;
+  const above1 = currentTick < clUpper ? up.feeGrowthOutside1X128 : g1 - up.feeGrowthOutside1X128;
+  return {
+    feeGrowthInside0X128: g0 - below0 - above0,
+    feeGrowthInside1X128: g1 - below1 - above1,
+  };
+}
+
+// ---------------- driver ----------------
+const Q128 = 2n ** 128n;
+const fmt = (x: bigint) => {
+  const a = x < 0n ? -x : x;
+  return `${x.toString()} (~${Number(a).toExponential(3)})`;
+};
+
+async function tickStatus(tick: number, block: bigint) {
+  const [lg, ln, fo0, fo1] = await client.readContract({
+    address: STATE_VIEW,
+    abi: STATE_VIEW_ABI,
+    functionName: "getTickInfo",
+    args: [POOL_ID, tick],
+    blockNumber: block,
+  });
+  return { initialized: lg !== 0n || ln !== 0n, liquidityGross: lg, liquidityNet: ln, fo0, fo1 };
+}
+
+async function reproPosition(
+  tokenId: bigint,
+  tickLower: number,
+  tickUpper: number,
+  startBlock: bigint,
+  endBlock: bigint,
+) {
+  console.log(`\n${"=".repeat(78)}`);
+  console.log(`TOKEN ${tokenId}  range [${tickLower}, ${tickUpper}]  spacing ${TICK_SPACING}`);
+  console.log(`sub-period start block ${startBlock}  ->  end block ${endBlock}`);
+  console.log("=".repeat(78));
+
+  // liquidity for the sub-period (constant; read at start block)
+  let liquidity = 0n;
+  try {
+    liquidity = await client.readContract({
+      address: POSITION_MANAGER,
+      abi: POSITION_MANAGER_ABI,
+      functionName: "getPositionLiquidity",
+      args: [tokenId],
+      blockNumber: startBlock,
+    });
+  } catch (e: any) {
+    console.log(`  (getPositionLiquidity reverted: ${e.shortMessage ?? e.message}; credited-TEL calc will be skipped)`);
+  }
+  console.log(`position liquidity @start: ${liquidity}`);
+
+  for (const [label, block] of [["START", startBlock], ["END", endBlock]] as const) {
+    const [, tick] = await client.readContract({
+      address: STATE_VIEW, abi: STATE_VIEW_ABI, functionName: "getSlot0", args: [POOL_ID], blockNumber: block,
+    });
+    const loS = await tickStatus(tickLower, block);
+    const upS = await tickStatus(tickUpper, block);
+    const inRange = tick >= tickLower && tick < tickUpper;
+    console.log(`\n[${label} @${block}] currentTick=${tick}  position ${inRange ? "IN range" : "OUT of range"}`);
+    console.log(`   tickLower ${tickLower} initialized=${loS.initialized} (liqGross=${loS.liquidityGross})`);
+    console.log(`   tickUpper ${tickUpper} initialized=${upS.initialized} (liqGross=${upS.liquidityGross})`);
+    const snapLo = await findInitializedTickUnder(client, POOL_ID, STATE_VIEW, tickLower, TICK_SPACING, block);
+    const snapUp = await findInitializedTickUnder(client, POOL_ID, STATE_VIEW, tickUpper, TICK_SPACING, block);
+    console.log(`   findInitializedTickUnder: ${tickLower} -> ${snapLo}${snapLo!==tickLower?"  *** SNAPPED ***":""},  ${tickUpper} -> ${snapUp}${snapUp!==tickUpper?"  *** SNAPPED ***":""}`);
+  }
+
+  // (1) BUGGY
+  const [bugStart, bugEnd] = await Promise.all([
+    getFeeGrowthInsideOffchain(client, POOL_ID, STATE_VIEW, tickLower, tickUpper, TICK_SPACING, startBlock),
+    getFeeGrowthInsideOffchain(client, POOL_ID, STATE_VIEW, tickLower, tickUpper, TICK_SPACING, endBlock),
+  ]);
+  // (2) CANONICAL
+  const [canStart, canEnd] = await Promise.all([
+    getFeeGrowthInsideCanonical(tickLower, tickUpper, startBlock),
+    getFeeGrowthInsideCanonical(tickLower, tickUpper, endBlock),
+  ]);
+  // (3) FIXED: clamp ONCE at start, reuse bounds at both endpoints
+  const [clLower, clUpper] = await clampTicksToInitialized(tickLower, tickUpper, TICK_SPACING, startBlock);
+  let fixStart = { feeGrowthInside0X128: 0n, feeGrowthInside1X128: 0n };
+  let fixEnd = { feeGrowthInside0X128: 0n, feeGrowthInside1X128: 0n };
+  if (clLower !== null && clUpper !== null) {
+    fixStart = await getFeeGrowthInsideOffchainAtBounds(clLower, clUpper, startBlock);
+    fixEnd = await getFeeGrowthInsideOffchainAtBounds(clLower, clUpper, endBlock);
+  }
+  console.log(`\nproposed-fix clamp @start: [${clLower}, ${clUpper}]`);
+
+  const credited = (
+    end: { feeGrowthInside0X128: bigint; feeGrowthInside1X128: bigint },
+    start: { feeGrowthInside0X128: bigint; feeGrowthInside1X128: bigint },
+  ) => calculateFees(liquidity, end.feeGrowthInside0X128, end.feeGrowthInside1X128, start.feeGrowthInside0X128, start.feeGrowthInside1X128);
+
+  const cBug = credited(bugEnd, bugStart);
+  const cCan = credited(canEnd, canStart);
+  const cFix = credited(fixEnd, fixStart);
+
+  console.log(`\n--- feeGrowthInside1 (TEL side) ---`);
+  console.log(`  BUGGY     start=${fmt(bugStart.feeGrowthInside1X128)}\n            end  =${fmt(bugEnd.feeGrowthInside1X128)}`);
+  console.log(`  CANONICAL start=${fmt(canStart.feeGrowthInside1X128)}\n            end  =${fmt(canEnd.feeGrowthInside1X128)}`);
+  console.log(`  FIXED     start=${fmt(fixStart.feeGrowthInside1X128)}\n            end  =${fmt(fixEnd.feeGrowthInside1X128)}`);
+
+  console.log(`\n--- credited token1Fees = delta1 * liquidity / 2^128  (raw integer) ---`);
+  console.log(`  BUGGY     token1Fees = ${cBug.token1Fees}`);
+  console.log(`  CANONICAL token1Fees = ${cCan.token1Fees}`);
+  console.log(`  FIXED     token1Fees = ${cFix.token1Fees}`);
+  console.log(`  (report claims calculator credited token 110585 = 65,099,934)`);
+}
+
+async function main() {
+  console.log("Polygon head:", await client.getBlockNumber());
+  // token 110585: the report's fully-specified worked example (Section 7.3)
+  await reproPosition(110585n, -233880, -233580, 88434042n, 88479276n);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/backend/sim/rerunPeriod44.ts
+++ b/backend/sim/rerunPeriod44.ts
@@ -1,0 +1,219 @@
+/**
+ * Period-44 re-run harness (Polygon ETH/TEL).
+ *
+ * Drives the REAL production code over the real period-44 block range, BOTH WAYS:
+ *   - BUGGY: getFeeGrowthInsideOffchain (legacy, recomputes bounds each endpoint)
+ *   - FIXED: clampTicksToInitialized + getFeeGrowthInsideOffchainAtBounds (the fix)
+ *
+ * Position discovery + liquidity timelines come from the production
+ * updatePositions(), so the sub-period structure is exactly what the calculator
+ * would see. RPC reads are cached to backend/rpc_cache so the run is repeatable.
+ *
+ * Run: npx ts-node backend/sim/rerunPeriod44.ts
+ *
+ * LIMITATION (stated honestly): a fully faithful period-44 run is impossible
+ * here because the calculator resumes from the period-43 checkpoint, which does
+ * not exist (we only have through period 33), and there is no Base RPC. This
+ * harness therefore starts from an EMPTY position set and discovers positions
+ * from period-44 events. That captures every position that was created or
+ * modified during the period - which includes all the narrow-range "phantom"
+ * farmers - but NOT long-lived passive positions that emitted no event in the
+ * window. Those are understated EQUALLY in both runs, so the buggy-vs-fixed
+ * comparison and the phantom collapse remain valid; only the absolute genuine-LP
+ * total is a lower bound.
+ */
+import { createPublicClient, http, type Address, type PublicClient } from "viem";
+import { polygon } from "viem/chains";
+import * as dotenv from "dotenv";
+import {
+  updatePositions,
+  getFeeGrowthInsideOffchain,
+  clampTicksToInitialized,
+  getFeeGrowthInsideOffchainAtBounds,
+  calculateFees,
+  NETWORKS,
+  type PositionState,
+} from "../calculators/TELxRewardsCalculator";
+import { cachedReadContract, cachedGetLogs, ensureDataDirectory, CACHE_DIR } from "../helpers";
+import { ChainId } from "../config";
+dotenv.config();
+
+const RPC = process.env.POLYGON_RPC_URL;
+if (!RPC) throw new Error("POLYGON_RPC_URL not set");
+
+// polygon-ETH-TEL
+const POOL_ID = "0x25412ca33f9a2069f0520708da3f70a7843374dd46dc1c7e62f6d5002f5f9fa7" as const;
+const TICK_SPACING = 60;
+const { stateView, positionRegistry, positionManager } = NETWORKS[ChainId.Polygon];
+
+// period-44 Polygon range (from the report; verified to be real mined blocks)
+const START_BLOCK = 88229743n;
+const END_BLOCK = 88632941n;
+const LOG_CHUNK = 50000n;
+
+ensureDataDirectory(CACHE_DIR);
+const realClient = createPublicClient({ chain: polygon, transport: http(RPC) }) as PublicClient;
+
+// caching + chunked-getLogs proxy so the heavy archive reads run once
+async function cachedGetLogsChunked(params: any): Promise<any[]> {
+  if (params.fromBlock === undefined || params.toBlock === undefined) {
+    return cachedGetLogs(realClient, params);
+  }
+  const out: any[] = [];
+  for (let from = BigInt(params.fromBlock); from <= BigInt(params.toBlock); from += LOG_CHUNK) {
+    const to = from + LOG_CHUNK - 1n > BigInt(params.toBlock) ? BigInt(params.toBlock) : from + LOG_CHUNK - 1n;
+    const chunk = await cachedGetLogs(realClient, { ...params, fromBlock: from, toBlock: to });
+    out.push(...chunk);
+  }
+  return out;
+}
+let gapHits = 0;
+let subRevertHits = 0;
+async function resilientRead(p: any): Promise<any> {
+  let bn: bigint | undefined = p.blockNumber;
+  for (let i = 0; i < 8; i++) {
+    try {
+      return await cachedReadContract(realClient, bn === undefined ? p : { ...p, blockNumber: bn });
+    } catch (e: any) {
+      const msg = String(e?.message || e);
+      // burned/unknown token: isTokenSubscribed reverts (zero-address state). not subscribed.
+      if (p.functionName === "isTokenSubscribed" && /is not found|revert/i.test(msg)) {
+        subRevertHits++;
+        return false;
+      }
+      // Alchemy archive-state gap at this exact block: step back to nearest available block
+      if (/is not found/i.test(msg) && bn !== undefined) {
+        bn = bn - 1n;
+        gapHits++;
+        continue;
+      }
+      throw e;
+    }
+  }
+  if (p.functionName === "isTokenSubscribed") return false;
+  throw new Error(`read failed after gap retries: ${p.functionName}`);
+}
+const client = new Proxy(realClient, {
+  get(target, prop, receiver) {
+    if (prop === "readContract") return (p: any) => resilientRead(p);
+    if (prop === "getLogs") return (p: any) => cachedGetLogsChunked(p);
+    const v = Reflect.get(target, prop, receiver);
+    return typeof v === "function" ? v.bind(target) : v;
+  },
+}) as PublicClient;
+
+interface PerPos {
+  tokenId: bigint;
+  tickLower: number;
+  tickUpper: number;
+  buggy1: bigint; // token1 (TEL) fees, summed over sub-periods
+  fixed1: bigint;
+  buggy0: bigint; // token0 (WETH) fees
+  fixed0: bigint;
+  subscribedBuggy1: bigint; // pot-relevant (subscribed sub-periods only)
+  subscribedFixed1: bigint;
+  hadPhantom: boolean;
+}
+
+async function feesForPosition(tokenId: bigint, position: PositionState): Promise<PerPos> {
+  const r: PerPos = {
+    tokenId, tickLower: position.tickLower, tickUpper: position.tickUpper,
+    buggy1: 0n, fixed1: 0n, buggy0: 0n, fixed0: 0n,
+    subscribedBuggy1: 0n, subscribedFixed1: 0n, hadPhantom: false,
+  };
+  for (let i = 1; i < position.liquidityModifications.length; i++) {
+    const prev = position.liquidityModifications[i - 1];
+    const curr = position.liquidityModifications[i];
+    const L = prev.newLiquidityAmount;
+    if (L === 0n || prev.blockNumber === curr.blockNumber) continue;
+
+    // BUGGY path (legacy getFeeGrowthInsideOffchain at each endpoint independently)
+    const [bStart, bEnd] = await Promise.all([
+      getFeeGrowthInsideOffchain(client, POOL_ID, stateView, position.tickLower, position.tickUpper, TICK_SPACING, prev.blockNumber),
+      getFeeGrowthInsideOffchain(client, POOL_ID, stateView, position.tickLower, position.tickUpper, TICK_SPACING, curr.blockNumber),
+    ]);
+    const cb = calculateFees(L, bEnd.feeGrowthInside0X128, bEnd.feeGrowthInside1X128, bStart.feeGrowthInside0X128, bStart.feeGrowthInside1X128);
+
+    // FIXED path (clamp once at start, reuse bounds at both endpoints)
+    let fStart = { feeGrowthInside0X128: 0n, feeGrowthInside1X128: 0n };
+    let fEnd = { feeGrowthInside0X128: 0n, feeGrowthInside1X128: 0n };
+    const [clL, clU] = await clampTicksToInitialized(client, POOL_ID, stateView, position.tickLower, position.tickUpper, TICK_SPACING, prev.blockNumber);
+    if (clL !== null && clU !== null && clL < clU) {
+      [fStart, fEnd] = await Promise.all([
+        getFeeGrowthInsideOffchainAtBounds(client, POOL_ID, stateView, clL, clU, prev.blockNumber),
+        getFeeGrowthInsideOffchainAtBounds(client, POOL_ID, stateView, clL, clU, curr.blockNumber),
+      ]);
+    }
+    const cf = calculateFees(L, fEnd.feeGrowthInside0X128, fEnd.feeGrowthInside1X128, fStart.feeGrowthInside0X128, fStart.feeGrowthInside1X128);
+
+    r.buggy0 += cb.token0Fees; r.buggy1 += cb.token1Fees;
+    r.fixed0 += cf.token0Fees; r.fixed1 += cf.token1Fees;
+    if (prev.isSubscribed) { r.subscribedBuggy1 += cb.token1Fees; r.subscribedFixed1 += cf.token1Fees; }
+    // flag a phantom sub-period: buggy credits >> fixed by a large margin
+    if (cb.token1Fees > cf.token1Fees + 1_000_000n) r.hadPhantom = true;
+  }
+  return r;
+}
+
+const tel = (raw: bigint) => (Number(raw) / 100).toLocaleString(undefined, { maximumFractionDigits: 2 }); // TEL has 2 decimals
+
+async function main() {
+  console.log(`Period-44 Polygon re-run: blocks ${START_BLOCK} -> ${END_BLOCK}`);
+  console.log(`stateView=${stateView}\nDiscovering positions from on-chain events (cached)...`);
+
+  const positions = await updatePositions(
+    POOL_ID, START_BLOCK, END_BLOCK, client, positionRegistry as Address, positionManager as Address, new Map(),
+  );
+  console.log(`Discovered ${positions.size} positions with in-period events. Computing fees both ways...\n`);
+
+  const results: PerPos[] = [];
+  let n = 0;
+  for (const [tokenId, position] of positions.entries()) {
+    results.push(await feesForPosition(tokenId, position));
+    n++;
+    if (n % 10 === 0) process.stdout.write(`  processed ${n}/${positions.size}\r`);
+  }
+
+  results.sort((a, b) => (b.buggy1 > a.buggy1 ? 1 : b.buggy1 < a.buggy1 ? -1 : 0));
+
+  const totalBuggy = results.reduce((s, r) => s + r.subscribedBuggy1, 0n);
+  const totalFixed = results.reduce((s, r) => s + r.subscribedFixed1, 0n);
+  const phantomCount = results.filter((r) => r.hadPhantom).length;
+
+  console.log(`\n${"=".repeat(96)}`);
+  console.log(`TOP POSITIONS by buggy TEL-side fees (subscribed pot-relevant in [] )`);
+  console.log("=".repeat(96));
+  console.log(`tokenId      range                    BUGGY token1 (TEL)        FIXED token1 (TEL)     phantom?`);
+  for (const r of results.slice(0, 25)) {
+    console.log(
+      `${r.tokenId.toString().padEnd(12)} [${r.tickLower},${r.tickUpper}]`.padEnd(40) +
+      `${tel(r.buggy1).padStart(22)}   ${tel(r.fixed1).padStart(22)}   ${r.hadPhantom ? "YES" : ""}`,
+    );
+  }
+
+  console.log(`\n${"=".repeat(96)}`);
+  console.log(`REPORT-NAMED POSITIONS`);
+  console.log("=".repeat(96));
+  for (const id of [110585n, 110646n, 109092n, 110776n]) {
+    const r = results.find((x) => x.tokenId === id);
+    if (r) {
+      console.log(`token ${id}  [${r.tickLower},${r.tickUpper}]  BUGGY token1=${tel(r.buggy1)} TEL   FIXED token1=${tel(r.fixed1)} TEL`);
+    } else {
+      console.log(`token ${id}  -- not discovered in period-44 event window (may be pre-period / different sub-period)`);
+    }
+  }
+
+  console.log(`\n${"=".repeat(96)}`);
+  console.log(`POOL-LEVEL (subscribed, TEL side only; token0/WETH side excluded for brevity)`);
+  console.log("=".repeat(96));
+  console.log(`  positions with a phantom sub-period: ${phantomCount} / ${results.length}`);
+  console.log(`  BUGGY  total credited (TEL): ${tel(totalBuggy)}`);
+  console.log(`  FIXED  total credited (TEL): ${tel(totalFixed)}`);
+  if (totalFixed > 0n) {
+    console.log(`  inflation factor (buggy/fixed): ${(Number(totalBuggy) / Number(totalFixed)).toFixed(1)}x`);
+  }
+  console.log(`  => report claims Polygon: real 55,697 TEL vs credited 996,874 TEL (17.9x)`);
+  console.log(`\n  [diagnostics] archive-gap block substitutions: ${gapHits} | isTokenSubscribed reverts treated as false: ${subRevertHits}`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
getFeeGrowthInsideOffchain rebuilt a position's fee growth by re-locating its initialized boundary ticks independently at each sub-period endpoint. When a narrow position's boundary ticks de-initialize after price moves out of range, findInitializedTickUnder snaps to unrelated ticks and reconstructs a phantom feeGrowthInside (~9e31), which the underflow guard in calculateFees then credits as real fees. On period 44 this over-credited a handful of positions by orders of magnitude (token 110585: raw 65,099,934 credited vs 0 earned on-chain).

Fix: clampTicksToInitialized computes the initialized bounds once at the sub-period START block, where the boundary ticks are still initialized, and getFeeGrowthInsideOffchainAtBounds reuses those exact bounds at both endpoints. If either clamped tick has de-initialized by the query block, the sub-period earns nothing. Legacy getFeeGrowthInsideOffchain / findInitializedTickUnder are retained for the inspectSwaps diagnostic and marked deprecated.

Verified against Polygon archive state: the buggy path reproduces the exact phantom figures, the fix returns 0 for the phantom positions, and genuine LP credits are byte-identical. Adds backend/sim/ validation scripts.