### PR TITLE
feat(issuance): upgrade TAN issuance to Tel V3 and V3 staking

### DIFF
--- a/backend/abi/SimplePlugin.ts
+++ b/backend/abi/SimplePlugin.ts
@@ -1,283 +1,765 @@
+// ABI of the V3 `SimplePlugin`. Generated from the tel-v3-staking forge artifact.
 export default [
   {
-    inputs: [
-      { internalType: "address", name: "_stakingAddress", type: "address" },
-    ],
-    stateMutability: "nonpayable",
     type: "constructor",
-  },
-  {
-    anonymous: false,
     inputs: [
       {
-        indexed: true,
-        internalType: "address",
-        name: "account",
         type: "address",
+        name: "_staking",
+        internalType: "address"
       },
       {
-        indexed: false,
-        internalType: "uint256",
-        name: "oldClaimable",
-        type: "uint256",
-      },
-      {
-        indexed: false,
-        internalType: "uint256",
-        name: "newClaimable",
-        type: "uint256",
-      },
-    ],
-    name: "ClaimableIncreased",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "account",
         type: "address",
-      },
-      {
-        indexed: false,
-        internalType: "uint256",
-        name: "amount",
-        type: "uint256",
-      },
+        name: "_rewardToken",
+        internalType: "address"
+      }
     ],
-    name: "Claimed",
-    type: "event",
+    stateMutability: "nonpayable"
   },
   {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: false,
-        internalType: "uint256",
-        name: "deactivationTime",
-        type: "uint256",
-      },
-    ],
-    name: "DeactivationInitiated",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "oldIncreaser",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "newIncreaser",
-        type: "address",
-      },
-    ],
-    name: "IncreaserChanged",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "previousOwner",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "newOwner",
-        type: "address",
-      },
-    ],
-    name: "OwnershipTransferred",
-    type: "event",
-  },
-  {
+    type: "function",
+    name: "NATIVE_TOKEN",
     inputs: [],
-    name: "_deactivated",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "_deactivationDelay",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "_deactivationTime",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "address", name: "to", type: "address" },
-      { internalType: "bytes", name: "", type: "bytes" },
-    ],
-    name: "claim",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "bytes", name: "", type: "bytes" },
-    ],
-    name: "claimable",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "uint256", name: "blockNumber", type: "uint256" },
-      { internalType: "bytes", name: "", type: "bytes" },
-    ],
-    name: "claimableAt",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "cleanupPostDeactivation",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "deactivated",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "uint256", name: "amount", type: "uint256" },
-    ],
-    name: "increaseClaimableBy",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "increaser",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "", type: "address" },
-      { internalType: "uint256", name: "", type: "uint256" },
-      { internalType: "uint256", name: "", type: "uint256" },
-    ],
-    name: "notifyStakeChange",
-    outputs: [],
-    stateMutability: "pure",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "owner",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "renounceOwnership",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "requiresNotification",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "pure",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "contract IERC20", name: "token", type: "address" },
-      { internalType: "address", name: "to", type: "address" },
-    ],
-    name: "rescueTokens",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "newIncreaser", type: "address" },
-    ],
-    name: "setIncreaser",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "staking",
     outputs: [
-      { internalType: "contract StakingModule", name: "", type: "address" },
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
     ],
-    stateMutability: "view",
-    type: "function",
+    stateMutability: "view"
   },
   {
+    type: "function",
+    name: "_deactivated",
     inputs: [],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "_deactivationDelay",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "_deactivationTime",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "claim",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "to",
+        internalType: "address"
+      },
+      {
+        type: "bytes",
+        name: "",
+        internalType: "bytes"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "claimable",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "bytes",
+        name: "",
+        internalType: "bytes"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "claimableAt",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "blockNumber",
+        internalType: "uint256"
+      },
+      {
+        type: "bytes",
+        name: "",
+        internalType: "bytes"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "cleanupPostDeactivation",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "deactivated",
+    inputs: [],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "increaseClaimableBy",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
+    name: "increaseClaimableByBatch",
+    inputs: [
+      {
+        type: "address[]",
+        name: "accounts",
+        internalType: "address[]"
+      },
+      {
+        type: "uint256[]",
+        name: "amounts",
+        internalType: "uint256[]"
+      },
+      {
+        type: "uint256",
+        name: "totalAmount",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
+    name: "increaser",
+    inputs: [],
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "isNative",
+    inputs: [],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "owner",
+    inputs: [],
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "pause",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "paused",
+    inputs: [],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "renounceOwnership",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "rescueTokens",
+    inputs: [
+      {
+        type: "address",
+        name: "token",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        internalType: "uint256"
+      },
+      {
+        type: "address",
+        name: "to",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "rewardToken",
+    inputs: [],
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "rewardToken_",
+    inputs: [],
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "setIncreaser",
+    inputs: [
+      {
+        type: "address",
+        name: "newIncreaser",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "staking",
+    inputs: [],
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "contract IStakingModule"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
     name: "startDeactivation",
+    inputs: [],
     outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    stateMutability: "nonpayable"
   },
   {
-    inputs: [{ internalType: "bytes4", name: "interfaceId", type: "bytes4" }],
+    type: "function",
     name: "supportsInterface",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "view",
-    type: "function",
+    inputs: [
+      {
+        type: "bytes4",
+        name: "interfaceId",
+        internalType: "bytes4"
+      }
+    ],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
   },
   {
-    inputs: [],
-    name: "tel",
-    outputs: [{ internalType: "contract IERC20", name: "", type: "address" }],
-    stateMutability: "view",
     type: "function",
-  },
-  {
-    inputs: [],
     name: "totalClaimable",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
   },
   {
-    inputs: [{ internalType: "address", name: "newOwner", type: "address" }],
-    name: "transferOwnership",
-    outputs: [],
-    stateMutability: "nonpayable",
     type: "function",
+    name: "transferOwnership",
+    inputs: [
+      {
+        type: "address",
+        name: "newOwner",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
   },
+  {
+    type: "function",
+    name: "unpause",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "event",
+    name: "ClaimableIncreased",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Claimed",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "to",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "DeactivationInitiated",
+    inputs: [
+      {
+        type: "uint256",
+        name: "deactivationTime",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "IncreaserChanged",
+    inputs: [
+      {
+        type: "address",
+        name: "oldIncreaser",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "newIncreaser",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferred",
+    inputs: [
+      {
+        type: "address",
+        name: "previousOwner",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "newOwner",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Paused",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: false,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Unpaused",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: false,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "error",
+    name: "AddressEmptyCode",
+    inputs: [
+      {
+        type: "address",
+        name: "target",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "AddressInsufficientBalance",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "BatchLengthMismatch",
+    inputs: [
+      {
+        type: "uint256",
+        name: "accountsLength",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "amountsLength",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "BatchTotalMismatch",
+    inputs: [
+      {
+        type: "uint256",
+        name: "declaredTotal",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "summedAmounts",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "CheckpointUnorderedInsertion",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "CheckpointValueExceedsMax",
+    inputs: [
+      {
+        type: "uint256",
+        name: "value",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "Deactivated",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "EmptyBatch",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "EnforcedPause",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "ExpectedPause",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "FailedInnerCall",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "FutureBlockNumber",
+    inputs: [
+      {
+        type: "uint256",
+        name: "blockNumber",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "currentBlock",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "MsgValueMismatch",
+    inputs: [
+      {
+        type: "uint256",
+        name: "expected",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "actual",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "NativeTransferFailed",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "NotIncreaser",
+    inputs: [
+      {
+        type: "address",
+        name: "caller",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "OnlyStaking",
+    inputs: [
+      {
+        type: "address",
+        name: "caller",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "OwnableInvalidOwner",
+    inputs: [
+      {
+        type: "address",
+        name: "owner",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "OwnableUnauthorizedAccount",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ReentrancyGuardReentrantCall",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "RescueExceedsFree",
+    inputs: [
+      {
+        type: "uint256",
+        name: "requested",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "free",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "SafeERC20FailedOperation",
+    inputs: [
+      {
+        type: "address",
+        name: "token",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "UnexpectedMsgValue",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "ZeroAddress",
+    inputs: []
+  }
 ] as const;

--- a/backend/abi/StakingModuleAbi.ts
+++ b/backend/abi/StakingModuleAbi.ts
@@ -1,614 +1,2370 @@
+// ABI of the V3 `StakingModule` (sTEL). Generated from the tel-v3-staking forge artifact.
 export default [
   {
-    anonymous: false,
+    type: "constructor",
     inputs: [
       {
-        indexed: true,
-        internalType: "address",
-        name: "account",
         type: "address",
+        name: "tel_",
+        internalType: "contract IERC20"
       },
       {
-        indexed: false,
-        internalType: "uint256",
-        name: "amount",
         type: "uint256",
-      },
+        name: "maxWithdrawalDelay_",
+        internalType: "uint256"
+      }
     ],
-    name: "Claimed",
-    type: "event",
+    stateMutability: "nonpayable"
   },
   {
-    anonymous: false,
-    inputs: [
-      { indexed: false, internalType: "uint8", name: "version", type: "uint8" },
-    ],
-    name: "Initialized",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "plugin",
-        type: "address",
-      },
-      {
-        indexed: false,
-        internalType: "uint256",
-        name: "nPlugins",
-        type: "uint256",
-      },
-    ],
-    name: "PluginAdded",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "plugin",
-        type: "address",
-      },
-    ],
-    name: "PluginClaimFailed",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "plugin",
-        type: "address",
-      },
-      {
-        indexed: false,
-        internalType: "uint256",
-        name: "nPlugins",
-        type: "uint256",
-      },
-    ],
-    name: "PluginRemoved",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "bytes32", name: "role", type: "bytes32" },
-      {
-        indexed: true,
-        internalType: "bytes32",
-        name: "previousAdminRole",
-        type: "bytes32",
-      },
-      {
-        indexed: true,
-        internalType: "bytes32",
-        name: "newAdminRole",
-        type: "bytes32",
-      },
-    ],
-    name: "RoleAdminChanged",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "bytes32", name: "role", type: "bytes32" },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "sender",
-        type: "address",
-      },
-    ],
-    name: "RoleGranted",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "bytes32", name: "role", type: "bytes32" },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "sender",
-        type: "address",
-      },
-    ],
-    name: "RoleRevoked",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-      {
-        indexed: false,
-        internalType: "uint256",
-        name: "amount",
-        type: "uint256",
-      },
-    ],
-    name: "Slashed",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "plugin",
-        type: "address",
-      },
-    ],
-    name: "StakeChangeNotificationFailed",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-      {
-        indexed: false,
-        internalType: "uint256",
-        name: "oldStake",
-        type: "uint256",
-      },
-      {
-        indexed: false,
-        internalType: "uint256",
-        name: "newStake",
-        type: "uint256",
-      },
-    ],
-    name: "StakeChanged",
-    type: "event",
-  },
-  {
+    type: "function",
+    name: "CLOCK_MODE",
     inputs: [],
+    outputs: [
+      {
+        type: "string",
+        name: "",
+        internalType: "string"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
     name: "DEFAULT_ADMIN_ROLE",
-    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
     inputs: [],
-    name: "MIGRATOR_ROLE",
-    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "PLUGIN_EDITOR_ROLE",
-    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "RECOVERY_ROLE",
-    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "SLASHER_ROLE",
-    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "plugin", type: "address" }],
-    name: "addPlugin",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "bytes", name: "auxData", type: "bytes" },
-    ],
-    name: "balanceOf",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "uint256", name: "blockNumber", type: "uint256" },
-      { internalType: "bytes", name: "auxData", type: "bytes" },
-    ],
-    name: "balanceOfAt",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "bytes", name: "auxData", type: "bytes" }],
-    name: "claim",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "address", name: "to", type: "address" },
-      { internalType: "bytes", name: "auxData", type: "bytes" },
-    ],
-    name: "claimAndExitFor",
     outputs: [
-      { internalType: "uint256", name: "", type: "uint256" },
-      { internalType: "uint256", name: "", type: "uint256" },
-    ],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "pluginAddress", type: "address" },
-      { internalType: "bytes", name: "auxData", type: "bytes" },
-    ],
-    name: "claimFromIndividualPlugin",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "bytes", name: "auxData", type: "bytes" },
-    ],
-    name: "claimable",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "uint256", name: "blockNumber", type: "uint256" },
-      { internalType: "bytes", name: "auxData", type: "bytes" },
-    ],
-    name: "claimableAt",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "exit",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "bytes", name: "auxData", type: "bytes" }],
-    name: "fullClaimAndExit",
-    outputs: [
-      { internalType: "uint256", name: "", type: "uint256" },
-      { internalType: "uint256", name: "", type: "uint256" },
-    ],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "bytes32", name: "role", type: "bytes32" }],
-    name: "getRoleAdmin",
-    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "bytes32", name: "role", type: "bytes32" },
-      { internalType: "uint256", name: "index", type: "uint256" },
-    ],
-    name: "getRoleMember",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "bytes32", name: "role", type: "bytes32" }],
-    name: "getRoleMemberCount",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "bytes32", name: "role", type: "bytes32" },
-      { internalType: "address", name: "account", type: "address" },
-    ],
-    name: "grantRole",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "bytes32", name: "role", type: "bytes32" },
-      { internalType: "address", name: "account", type: "address" },
-    ],
-    name: "hasRole",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "_telAddress", type: "address" },
-      { internalType: "uint256", name: "_maxWithdrawalDelay", type: "uint256" },
       {
-        internalType: "uint256",
-        name: "_minWithdrawalWindow",
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "DOMAIN_SEPARATOR",
+    inputs: [],
+    outputs: [
+      {
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "MAX_DELAY_INCREASE_PER_DAY",
+    inputs: [],
+    outputs: [
+      {
         type: "uint256",
-      },
+        name: "",
+        internalType: "uint256"
+      }
     ],
-    name: "initialize",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    stateMutability: "view"
   },
   {
+    type: "function",
+    name: "MAX_PENDING_WITHDRAWALS_PER_USER",
     inputs: [],
-    name: "maxWithdrawalDelay",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "minWithdrawalWindow",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "nPlugins",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "bytes", name: "auxData", type: "bytes" }],
-    name: "parseAuxData",
-    outputs: [{ internalType: "bytes[]", name: "", type: "bytes[]" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "uint256", name: "amount", type: "uint256" },
-      { internalType: "bytes", name: "auxData", type: "bytes" },
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
     ],
-    name: "partialClaimAndExit",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    stateMutability: "view"
   },
   {
-    inputs: [{ internalType: "uint256", name: "amount", type: "uint256" }],
-    name: "partialExit",
-    outputs: [],
-    stateMutability: "nonpayable",
     type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "", type: "address" }],
-    name: "pluginIndicies",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    name: "plugins",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "", type: "address" }],
-    name: "pluginsMapping",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "uint256", name: "index", type: "uint256" }],
-    name: "removePlugin",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "uint256", name: "index", type: "uint256" }],
-    name: "removePluginAdmin",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "bytes32", name: "role", type: "bytes32" },
-      { internalType: "address", name: "account", type: "address" },
-    ],
-    name: "renounceRole",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
+    name: "MAX_TIMING_BOUND",
     inputs: [],
-    name: "requestWithdrawal",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
   },
   {
+    type: "function",
+    name: "MIGRATOR_ROLE",
+    inputs: [],
+    outputs: [
+      {
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "NATIVE_TOKEN",
+    inputs: [],
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "PARAM_SETTER_ROLE",
+    inputs: [],
+    outputs: [
+      {
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "PAUSER_ROLE",
+    inputs: [],
+    outputs: [
+      {
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "PLUGIN_EDITOR_ROLE",
+    inputs: [],
+    outputs: [
+      {
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "RECOVERY_ROLE",
+    inputs: [],
+    outputs: [
+      {
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "UPGRADER_ROLE",
+    inputs: [],
+    outputs: [
+      {
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "UPGRADE_INTERFACE_VERSION",
+    inputs: [],
+    outputs: [
+      {
+        type: "string",
+        name: "",
+        internalType: "string"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "addPlugin",
     inputs: [
       {
-        internalType: "contract IERC20Upgradeable",
-        name: "token",
         type: "address",
+        name: "plugin",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "adminRemovePlugin",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "allowance",
+    inputs: [
+      {
+        type: "address",
+        name: "owner",
+        internalType: "address"
       },
-      { internalType: "address", name: "to", type: "address" },
+      {
+        type: "address",
+        name: "spender",
+        internalType: "address"
+      }
     ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      {
+        type: "address",
+        name: "spender",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "value",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "cancelWithdrawal",
+    inputs: [
+      {
+        type: "uint256",
+        name: "withdrawalId",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "checkpoints",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "uint32",
+        name: "pos",
+        internalType: "uint32"
+      }
+    ],
+    outputs: [
+      {
+        type: "tuple",
+        name: "",
+        internalType: "struct Checkpoints.Checkpoint208",
+        components: [
+          {
+            type: "uint48",
+            name: "_key",
+            internalType: "uint48"
+          },
+          {
+            type: "uint208",
+            name: "_value",
+            internalType: "uint208"
+          }
+        ]
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "claimFromIndividualPlugin",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      },
+      {
+        type: "bytes",
+        name: "auxData",
+        internalType: "bytes"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "claimFromMany",
+    inputs: [
+      {
+        type: "address[]",
+        name: "pluginList",
+        internalType: "address[]"
+      },
+      {
+        type: "bytes[]",
+        name: "auxData",
+        internalType: "bytes[]"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256[]",
+        name: "claimed",
+        internalType: "uint256[]"
+      }
+    ],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "claimableAtFrom",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "blockNumber",
+        internalType: "uint256"
+      },
+      {
+        type: "address[]",
+        name: "pluginList",
+        internalType: "address[]"
+      },
+      {
+        type: "bytes[]",
+        name: "auxData",
+        internalType: "bytes[]"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256[]",
+        name: "amounts",
+        internalType: "uint256[]"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "claimableFrom",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "address[]",
+        name: "pluginList",
+        internalType: "address[]"
+      },
+      {
+        type: "bytes[]",
+        name: "auxData",
+        internalType: "bytes[]"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256[]",
+        name: "amounts",
+        internalType: "uint256[]"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "clock",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint48",
+        name: "",
+        internalType: "uint48"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "decimals",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint8",
+        name: "",
+        internalType: "uint8"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "delegate",
+    inputs: [
+      {
+        type: "address",
+        name: "delegatee",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "delegateBySig",
+    inputs: [
+      {
+        type: "address",
+        name: "delegatee",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "nonce",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "expiry",
+        internalType: "uint256"
+      },
+      {
+        type: "uint8",
+        name: "v",
+        internalType: "uint8"
+      },
+      {
+        type: "bytes32",
+        name: "r",
+        internalType: "bytes32"
+      },
+      {
+        type: "bytes32",
+        name: "s",
+        internalType: "bytes32"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "delegates",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "eip712Domain",
+    inputs: [],
+    outputs: [
+      {
+        type: "bytes1",
+        name: "fields",
+        internalType: "bytes1"
+      },
+      {
+        type: "string",
+        name: "name",
+        internalType: "string"
+      },
+      {
+        type: "string",
+        name: "version",
+        internalType: "string"
+      },
+      {
+        type: "uint256",
+        name: "chainId",
+        internalType: "uint256"
+      },
+      {
+        type: "address",
+        name: "verifyingContract",
+        internalType: "address"
+      },
+      {
+        type: "bytes32",
+        name: "salt",
+        internalType: "bytes32"
+      },
+      {
+        type: "uint256[]",
+        name: "extensions",
+        internalType: "uint256[]"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "exit",
+    inputs: [
+      {
+        type: "uint256",
+        name: "withdrawalId",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "getPastTotalSupply",
+    inputs: [
+      {
+        type: "uint256",
+        name: "timepoint",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "getPastVotes",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "timepoint",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "getRoleAdmin",
+    inputs: [
+      {
+        type: "bytes32",
+        name: "role",
+        internalType: "bytes32"
+      }
+    ],
+    outputs: [
+      {
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "getVotes",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "getWithdrawal",
+    inputs: [
+      {
+        type: "uint256",
+        name: "id",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "tuple",
+        name: "",
+        internalType: "struct IStakingModule.Withdrawal",
+        components: [
+          {
+            type: "address",
+            name: "owner",
+            internalType: "address"
+          },
+          {
+            type: "uint128",
+            name: "amount",
+            internalType: "uint128"
+          },
+          {
+            type: "uint64",
+            name: "unlockTime",
+            internalType: "uint64"
+          }
+        ]
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "grantRole",
+    inputs: [
+      {
+        type: "bytes32",
+        name: "role",
+        internalType: "bytes32"
+      },
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "hasRole",
+    inputs: [
+      {
+        type: "bytes32",
+        name: "role",
+        internalType: "bytes32"
+      },
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "initialize",
+    inputs: [
+      {
+        type: "uint256",
+        name: "initialWithdrawalDelay_",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "migrationDuration_",
+        internalType: "uint256"
+      },
+      {
+        type: "address",
+        name: "initialAdmin_",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "isPlugin",
+    inputs: [
+      {
+        type: "address",
+        name: "p",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "maxWithdrawalDelay",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "migrationDeadline",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "name",
+    inputs: [],
+    outputs: [
+      {
+        type: "string",
+        name: "",
+        internalType: "string"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "nonces",
+    inputs: [
+      {
+        type: "address",
+        name: "owner",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "numCheckpoints",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint32",
+        name: "",
+        internalType: "uint32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "pause",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "paused",
+    inputs: [],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "pendingWithdrawalCount",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "pendingWithdrawalIds",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256[]",
+        name: "",
+        internalType: "uint256[]"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "permit",
+    inputs: [
+      {
+        type: "address",
+        name: "owner",
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "spender",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "value",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "deadline",
+        internalType: "uint256"
+      },
+      {
+        type: "uint8",
+        name: "v",
+        internalType: "uint8"
+      },
+      {
+        type: "bytes32",
+        name: "r",
+        internalType: "bytes32"
+      },
+      {
+        type: "bytes32",
+        name: "s",
+        internalType: "bytes32"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "pluginCount",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "plugins",
+    inputs: [
+      {
+        type: "uint256",
+        name: "offset",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "limit",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "address[]",
+        name: "",
+        internalType: "address[]"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "proxiableUUID",
+    inputs: [],
+    outputs: [
+      {
+        type: "bytes32",
+        name: "",
+        internalType: "bytes32"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "removePlugin",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "renounceRole",
+    inputs: [
+      {
+        type: "bytes32",
+        name: "role",
+        internalType: "bytes32"
+      },
+      {
+        type: "address",
+        name: "callerConfirmation",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "requestWithdrawal",
+    inputs: [
+      {
+        type: "uint256",
+        name: "amount",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "withdrawalId",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
     name: "rescueTokens",
+    inputs: [
+      {
+        type: "address",
+        name: "token",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        internalType: "uint256"
+      },
+      {
+        type: "address",
+        name: "to",
+        internalType: "address"
+      }
+    ],
     outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    stateMutability: "nonpayable"
   },
   {
-    inputs: [
-      { internalType: "bytes32", name: "role", type: "bytes32" },
-      { internalType: "address", name: "account", type: "address" },
-    ],
+    type: "function",
     name: "revokeRole",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
     inputs: [
-      { internalType: "uint256", name: "delay", type: "uint256" },
-      { internalType: "uint256", name: "window", type: "uint256" },
+      {
+        type: "bytes32",
+        name: "role",
+        internalType: "bytes32"
+      },
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
     ],
-    name: "setWithdrawDelayAndWindow",
     outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    stateMutability: "nonpayable"
   },
   {
+    type: "function",
+    name: "setWithdrawalDelay",
     inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "uint256", name: "amount", type: "uint256" },
-      { internalType: "address", name: "to", type: "address" },
-      { internalType: "bytes", name: "auxData", type: "bytes" },
+      {
+        type: "uint256",
+        name: "newDelay",
+        internalType: "uint256"
+      }
     ],
-    name: "slash",
     outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    stateMutability: "nonpayable"
   },
   {
-    inputs: [{ internalType: "uint256", name: "amount", type: "uint256" }],
+    type: "function",
     name: "stake",
+    inputs: [
+      {
+        type: "uint256",
+        name: "amount",
+        internalType: "uint256"
+      }
+    ],
     outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    stateMutability: "nonpayable"
   },
   {
-    inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "uint256", name: "amount", type: "uint256" },
-    ],
+    type: "function",
     name: "stakeFor",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "account", type: "address" }],
-    name: "stakedBy",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
     inputs: [
-      { internalType: "address", name: "account", type: "address" },
-      { internalType: "uint256", name: "blockNumber", type: "uint256" },
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        internalType: "uint256"
+      }
     ],
-    name: "stakedByAt",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
+    outputs: [],
+    stateMutability: "nonpayable"
   },
   {
-    inputs: [{ internalType: "bytes4", name: "interfaceId", type: "bytes4" }],
+    type: "function",
+    name: "stakeForBatch",
+    inputs: [
+      {
+        type: "address[]",
+        name: "accounts",
+        internalType: "address[]"
+      },
+      {
+        type: "uint256[]",
+        name: "amounts",
+        internalType: "uint256[]"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
     name: "supportsInterface",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "view",
-    type: "function",
+    inputs: [
+      {
+        type: "bytes4",
+        name: "interfaceId",
+        internalType: "bytes4"
+      }
+    ],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
   },
   {
+    type: "function",
+    name: "symbol",
     inputs: [],
+    outputs: [
+      {
+        type: "string",
+        name: "",
+        internalType: "string"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
     name: "tel",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
+    inputs: [],
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
   },
   {
-    inputs: [],
-    name: "totalStaked",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
     type: "function",
+    name: "totalPendingWithdrawal",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
   },
   {
-    inputs: [],
+    type: "function",
     name: "totalSupply",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
+    inputs: [],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
   },
   {
+    type: "function",
+    name: "transfer",
+    inputs: [
+      {
+        type: "address",
+        name: "to",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "value",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "transferFrom",
+    inputs: [
+      {
+        type: "address",
+        name: "from",
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "to",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "value",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "unpause",
     inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "upgradeToAndCall",
+    inputs: [
+      {
+        type: "address",
+        name: "newImplementation",
+        internalType: "address"
+      },
+      {
+        type: "bytes",
+        name: "data",
+        internalType: "bytes"
+      }
+    ],
+    outputs: [],
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
     name: "withdrawalDelay",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "", type: "address" }],
-    name: "withdrawalRequestTimestamps",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
     inputs: [],
-    name: "withdrawalWindow",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
   },
+  {
+    type: "event",
+    name: "Approval",
+    inputs: [
+      {
+        type: "address",
+        name: "owner",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "spender",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "value",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "DelegateChanged",
+    inputs: [
+      {
+        type: "address",
+        name: "delegator",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "fromDelegate",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "toDelegate",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "DelegateVotesChanged",
+    inputs: [
+      {
+        type: "address",
+        name: "delegate",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "previousVotes",
+        indexed: false,
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "newVotes",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "EIP712DomainChanged",
+    inputs: [],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Exited",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "withdrawalId",
+        indexed: true,
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Initialized",
+    inputs: [
+      {
+        type: "uint64",
+        name: "version",
+        indexed: false,
+        internalType: "uint64"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "InstantWithdrawal",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Paused",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: false,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "PluginAdded",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "PluginRemoved",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Rescued",
+    inputs: [
+      {
+        type: "address",
+        name: "token",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        indexed: false,
+        internalType: "uint256"
+      },
+      {
+        type: "address",
+        name: "to",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "RoleAdminChanged",
+    inputs: [
+      {
+        type: "bytes32",
+        name: "role",
+        indexed: true,
+        internalType: "bytes32"
+      },
+      {
+        type: "bytes32",
+        name: "previousAdminRole",
+        indexed: true,
+        internalType: "bytes32"
+      },
+      {
+        type: "bytes32",
+        name: "newAdminRole",
+        indexed: true,
+        internalType: "bytes32"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "RoleGranted",
+    inputs: [
+      {
+        type: "bytes32",
+        name: "role",
+        indexed: true,
+        internalType: "bytes32"
+      },
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "sender",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "RoleRevoked",
+    inputs: [
+      {
+        type: "bytes32",
+        name: "role",
+        indexed: true,
+        internalType: "bytes32"
+      },
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "sender",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Staked",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Transfer",
+    inputs: [
+      {
+        type: "address",
+        name: "from",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "to",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "value",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Unpaused",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: false,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Upgraded",
+    inputs: [
+      {
+        type: "address",
+        name: "implementation",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "WithdrawalCancelled",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "withdrawalId",
+        indexed: true,
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "WithdrawalDelaySet",
+    inputs: [
+      {
+        type: "uint256",
+        name: "oldDelay",
+        indexed: false,
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "newDelay",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "WithdrawalRequested",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "withdrawalId",
+        indexed: true,
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "error",
+    name: "AccessControlBadConfirmation",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "AccessControlUnauthorizedAccount",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "bytes32",
+        name: "neededRole",
+        internalType: "bytes32"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "AddressEmptyCode",
+    inputs: [
+      {
+        type: "address",
+        name: "target",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "AddressInsufficientBalance",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "CheckpointUnorderedInsertion",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "DelayExceedsMax",
+    inputs: [
+      {
+        type: "uint256",
+        name: "requested",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "max",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "DelayIncreaseTooFast",
+    inputs: [
+      {
+        type: "uint256",
+        name: "requested",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "maxAllowed",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ECDSAInvalidSignature",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "ECDSAInvalidSignatureLength",
+    inputs: [
+      {
+        type: "uint256",
+        name: "length",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ECDSAInvalidSignatureS",
+    inputs: [
+      {
+        type: "bytes32",
+        name: "s",
+        internalType: "bytes32"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC1967InvalidImplementation",
+    inputs: [
+      {
+        type: "address",
+        name: "implementation",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC1967NonPayable",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "ERC20ExceededSafeSupply",
+    inputs: [
+      {
+        type: "uint256",
+        name: "increasedSupply",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "cap",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC20InsufficientAllowance",
+    inputs: [
+      {
+        type: "address",
+        name: "spender",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "allowance",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "needed",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC20InsufficientBalance",
+    inputs: [
+      {
+        type: "address",
+        name: "sender",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "balance",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "needed",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC20InvalidApprover",
+    inputs: [
+      {
+        type: "address",
+        name: "approver",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC20InvalidReceiver",
+    inputs: [
+      {
+        type: "address",
+        name: "receiver",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC20InvalidSender",
+    inputs: [
+      {
+        type: "address",
+        name: "sender",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC20InvalidSpender",
+    inputs: [
+      {
+        type: "address",
+        name: "spender",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC2612ExpiredSignature",
+    inputs: [
+      {
+        type: "uint256",
+        name: "deadline",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC2612InvalidSigner",
+    inputs: [
+      {
+        type: "address",
+        name: "signer",
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "owner",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC5805FutureLookup",
+    inputs: [
+      {
+        type: "uint256",
+        name: "timepoint",
+        internalType: "uint256"
+      },
+      {
+        type: "uint48",
+        name: "clock",
+        internalType: "uint48"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ERC6372InconsistentClock",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "EmptyBatch",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "EnforcedPause",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "ExpectedPause",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "FailedInnerCall",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "InsufficientSTel",
+    inputs: [
+      {
+        type: "uint256",
+        name: "requested",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "available",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "InvalidAccountNonce",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "currentNonce",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "InvalidInitialization",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "LengthMismatch",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "MigrationEnded",
+    inputs: [
+      {
+        type: "uint256",
+        name: "deadline",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "NotInitializing",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "NotWithdrawalOwner",
+    inputs: [
+      {
+        type: "address",
+        name: "caller",
+        internalType: "address"
+      },
+      {
+        type: "address",
+        name: "owner",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "PluginAlreadyDeactivated",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "PluginAlreadyRegistered",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "PluginMisreported",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "expected",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "actual",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "PluginNotDeactivated",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "PluginNotIPlugin",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "PluginZeroRewardToken",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ReentrancyGuardReentrantCall",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "SafeCastOverflowedUintDowncast",
+    inputs: [
+      {
+        type: "uint8",
+        name: "bits",
+        internalType: "uint8"
+      },
+      {
+        type: "uint256",
+        name: "value",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "SafeERC20FailedOperation",
+    inputs: [
+      {
+        type: "address",
+        name: "token",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "TelRescueExceedsFree",
+    inputs: [
+      {
+        type: "uint256",
+        name: "requested",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "free",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "TelTransferMismatch",
+    inputs: [
+      {
+        type: "uint256",
+        name: "expected",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "received",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "TimingBoundExceeded",
+    inputs: [
+      {
+        type: "uint256",
+        name: "requested",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "bound",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "TooManyPendingWithdrawals",
+    inputs: [
+      {
+        type: "uint256",
+        name: "max",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "UUPSUnauthorizedCallContext",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "UUPSUnsupportedProxiableUUID",
+    inputs: [
+      {
+        type: "bytes32",
+        name: "slot",
+        internalType: "bytes32"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "UnknownPlugin",
+    inputs: [
+      {
+        type: "address",
+        name: "plugin",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "VotesExpiredSignature",
+    inputs: [
+      {
+        type: "uint256",
+        name: "expiry",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "WithdrawalEmpty",
+    inputs: [
+      {
+        type: "uint256",
+        name: "id",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "WithdrawalStillInDelay",
+    inputs: [
+      {
+        type: "uint256",
+        name: "unlockTime",
+        internalType: "uint256"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "ZeroAddress",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "ZeroAmount",
+    inputs: []
+  }
 ] as const;

--- a/backend/abi/TanIssuanceHistoryAbi.ts
+++ b/backend/abi/TanIssuanceHistoryAbi.ts
@@ -1,211 +1,531 @@
+// ABI of `TANIssuanceHistory`. Generated from this repo's forge artifact via `forge build`.
 export default [
   {
     type: "constructor",
     inputs: [
       {
-        name: "tanIssuancePlugin_",
         type: "address",
-        internalType: "contract ISimplePlugin",
+        name: "tanIssuancePlugin_",
+        internalType: "contract ISimplePlugin"
       },
+      {
+        type: "address",
+        name: "owner_",
+        internalType: "address"
+      }
     ],
-    stateMutability: "nonpayable",
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "receive",
+    stateMutability: "payable"
   },
   {
     type: "function",
     name: "CLOCK_MODE",
     inputs: [],
-    outputs: [{ name: "", type: "string", internalType: "string" }],
-    stateMutability: "view",
+    outputs: [
+      {
+        type: "string",
+        name: "",
+        internalType: "string"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "backfillCumulativeRewards",
+    inputs: [
+      {
+        type: "address[]",
+        name: "accounts",
+        internalType: "address[]"
+      },
+      {
+        type: "uint256[]",
+        name: "cumulativeAmounts",
+        internalType: "uint256[]"
+      },
+      {
+        type: "uint256",
+        name: "atBlock",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "backfillSealed",
+    inputs: [],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
   },
   {
     type: "function",
     name: "clock",
     inputs: [],
-    outputs: [{ name: "", type: "uint48", internalType: "uint48" }],
-    stateMutability: "view",
+    outputs: [
+      {
+        type: "uint48",
+        name: "",
+        internalType: "uint48"
+      }
+    ],
+    stateMutability: "view"
   },
   {
     type: "function",
     name: "cumulativeRewards",
-    inputs: [{ name: "account", type: "address", internalType: "address" }],
-    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
-    stateMutability: "view",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
   },
   {
     type: "function",
     name: "cumulativeRewardsAtBlock",
     inputs: [
-      { name: "account", type: "address", internalType: "address" },
-      { name: "queryBlock", type: "uint256", internalType: "uint256" },
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "queryBlock",
+        internalType: "uint256"
+      }
     ],
-    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
-    stateMutability: "view",
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
   },
   {
     type: "function",
     name: "cumulativeRewardsAtBlockBatched",
     inputs: [
-      { name: "accounts", type: "address[]", internalType: "address[]" },
-      { name: "queryBlock", type: "uint256", internalType: "uint256" },
+      {
+        type: "address[]",
+        name: "accounts",
+        internalType: "address[]"
+      },
+      {
+        type: "uint256",
+        name: "queryBlock",
+        internalType: "uint256"
+      }
     ],
     outputs: [
-      { name: "", type: "address[]", internalType: "address[]" },
-      { name: "", type: "uint256[]", internalType: "uint256[]" },
+      {
+        type: "address[]",
+        name: "",
+        internalType: "address[]"
+      },
+      {
+        type: "uint256[]",
+        name: "",
+        internalType: "uint256[]"
+      }
     ],
-    stateMutability: "view",
+    stateMutability: "view"
   },
   {
     type: "function",
     name: "deactivated",
     inputs: [],
-    outputs: [{ name: "", type: "bool", internalType: "bool" }],
-    stateMutability: "view",
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
   },
   {
     type: "function",
     name: "increaseClaimableByBatch",
     inputs: [
-      { name: "accounts", type: "address[]", internalType: "address[]" },
-      { name: "amounts", type: "uint256[]", internalType: "uint256[]" },
+      {
+        type: "tuple[]",
+        name: "rewards",
+        internalType: "struct TANIssuanceHistory.IssuanceReward[]",
+        components: [
+          {
+            type: "address",
+            name: "account",
+            internalType: "address"
+          },
+          {
+            type: "uint256",
+            name: "amount",
+            internalType: "uint256"
+          }
+        ]
+      },
+      {
+        type: "uint256",
+        name: "endBlock",
+        internalType: "uint256"
+      }
     ],
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "nonpayable"
   },
   {
     type: "function",
     name: "lastSettlementBlock",
     inputs: [],
-    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
-    stateMutability: "view",
+    outputs: [
+      {
+        type: "uint256",
+        name: "",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
   },
   {
     type: "function",
     name: "owner",
     inputs: [],
-    outputs: [{ name: "", type: "address", internalType: "address" }],
-    stateMutability: "view",
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
   },
   {
     type: "function",
     name: "renounceOwnership",
     inputs: [],
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "nonpayable"
   },
   {
     type: "function",
     name: "rescueTokens",
     inputs: [
-      { name: "token", type: "address", internalType: "contract IERC20" },
-      { name: "to", type: "address", internalType: "address" },
+      {
+        type: "address",
+        name: "token",
+        internalType: "contract IERC20"
+      },
+      {
+        type: "address",
+        name: "recipient",
+        internalType: "address"
+      }
     ],
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "sealBackfill",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "setTanIssuancePlugin",
+    inputs: [
+      {
+        type: "address",
+        name: "newPlugin",
+        internalType: "contract ISimplePlugin"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
   },
   {
     type: "function",
     name: "tanIssuancePlugin",
     inputs: [],
     outputs: [
-      { name: "", type: "address", internalType: "contract ISimplePlugin" },
+      {
+        type: "address",
+        name: "",
+        internalType: "contract ISimplePlugin"
+      }
     ],
-    stateMutability: "view",
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "tel",
+    inputs: [],
+    outputs: [
+      {
+        type: "address",
+        name: "",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "telIsNative",
+    inputs: [],
+    outputs: [
+      {
+        type: "bool",
+        name: "",
+        internalType: "bool"
+      }
+    ],
+    stateMutability: "view"
   },
   {
     type: "function",
     name: "transferOwnership",
-    inputs: [{ name: "newOwner", type: "address", internalType: "address" }],
+    inputs: [
+      {
+        type: "address",
+        name: "newOwner",
+        internalType: "address"
+      }
+    ],
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "event",
+    name: "BackfillSealed",
+    inputs: [],
+    anonymous: false
   },
   {
     type: "event",
     name: "ClaimableIncreased",
     inputs: [
       {
-        name: "account",
         type: "address",
+        name: "account",
         indexed: true,
-        internalType: "address",
+        internalType: "address"
       },
       {
+        type: "uint256",
         name: "oldClaimable",
-        type: "uint256",
         indexed: false,
-        internalType: "uint256",
+        internalType: "uint256"
       },
       {
-        name: "newClaimable",
         type: "uint256",
+        name: "newClaimable",
         indexed: false,
-        internalType: "uint256",
-      },
+        internalType: "uint256"
+      }
     ],
-    anonymous: false,
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "CumulativeRewardsBackfilled",
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        type: "uint256",
+        name: "amount",
+        indexed: false,
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "atBlock",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
   },
   {
     type: "event",
     name: "OwnershipTransferred",
     inputs: [
       {
-        name: "previousOwner",
         type: "address",
+        name: "previousOwner",
         indexed: true,
-        internalType: "address",
+        internalType: "address"
       },
       {
-        name: "newOwner",
         type: "address",
+        name: "newOwner",
         indexed: true,
-        internalType: "address",
-      },
+        internalType: "address"
+      }
     ],
-    anonymous: false,
+    anonymous: false
   },
   {
     type: "error",
-    name: "AddressEmptyCode",
-    inputs: [{ name: "target", type: "address", internalType: "address" }],
+    name: "BackfillIsSealed",
+    inputs: []
   },
   {
     type: "error",
-    name: "AddressInsufficientBalance",
-    inputs: [{ name: "account", type: "address", internalType: "address" }],
+    name: "BackfillLengthMismatch",
+    inputs: [
+      {
+        type: "uint256",
+        name: "accountsLength",
+        internalType: "uint256"
+      },
+      {
+        type: "uint256",
+        name: "amountsLength",
+        internalType: "uint256"
+      }
+    ]
   },
-  { type: "error", name: "ArityMismatch", inputs: [] },
-  { type: "error", name: "CheckpointUnorderedInsertion", inputs: [] },
-  { type: "error", name: "Deactivated", inputs: [] },
-  { type: "error", name: "ERC6372InconsistentClock", inputs: [] },
-  { type: "error", name: "FailedInnerCall", inputs: [] },
+  {
+    type: "error",
+    name: "CheckpointUnorderedInsertion",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "ERC6372InconsistentClock",
+    inputs: []
+  },
   {
     type: "error",
     name: "FutureLookup",
     inputs: [
-      { name: "queriedBlock", type: "uint256", internalType: "uint256" },
-      { name: "clockBlock", type: "uint48", internalType: "uint48" },
-    ],
+      {
+        type: "uint256",
+        name: "queriedBlock",
+        internalType: "uint256"
+      },
+      {
+        type: "uint48",
+        name: "clockBlock",
+        internalType: "uint48"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "IncompatiblePlugin",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "IncreaseClaimableByBatchFailed",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "InvalidAddress",
+    inputs: [
+      {
+        type: "address",
+        name: "invalidAddress",
+        internalType: "address"
+      }
+    ]
+  },
+  {
+    type: "error",
+    name: "InvalidBlock",
+    inputs: [
+      {
+        type: "uint256",
+        name: "endBlock",
+        internalType: "uint256"
+      }
+    ]
   },
   {
     type: "error",
     name: "OwnableInvalidOwner",
-    inputs: [{ name: "owner", type: "address", internalType: "address" }],
+    inputs: [
+      {
+        type: "address",
+        name: "owner",
+        internalType: "address"
+      }
+    ]
   },
   {
     type: "error",
     name: "OwnableUnauthorizedAccount",
-    inputs: [{ name: "account", type: "address", internalType: "address" }],
+    inputs: [
+      {
+        type: "address",
+        name: "account",
+        internalType: "address"
+      }
+    ]
   },
   {
     type: "error",
     name: "SafeCastOverflowedUintDowncast",
     inputs: [
-      { name: "bits", type: "uint8", internalType: "uint8" },
-      { name: "value", type: "uint256", internalType: "uint256" },
-    ],
+      {
+        type: "uint8",
+        name: "bits",
+        internalType: "uint8"
+      },
+      {
+        type: "uint256",
+        name: "value",
+        internalType: "uint256"
+      }
+    ]
   },
   {
     type: "error",
     name: "SafeERC20FailedOperation",
-    inputs: [{ name: "token", type: "address", internalType: "address" }],
+    inputs: [
+      {
+        type: "address",
+        name: "token",
+        internalType: "address"
+      }
+    ]
   },
+  {
+    type: "error",
+    name: "UnexpectedNative",
+    inputs: []
+  }
 ] as const;

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import { existsSync } from "fs";
 import { LocalFileExecutorRegistry } from "./datasources/ExecutorRegistry";
 import { BlocksDatabase } from "./datasources/persistent/BlocksDatabase";
-import { ChainId, config } from "./config";
+import { assertTelTokensConfigured, ChainId, config } from "./config";
 import {
   parseAndSanitizeCLIArgs,
   validateStartAndEndBlocks,
@@ -49,6 +49,10 @@ async function main() {
     );
     process.exit(1);
   }
+
+  // fail before any RPC work if a reward token address is still unpopulated, since an unset
+  // address would match no transfers and quietly yield an empty reward set
+  assertTelTokensConfigured();
 
   const networks = parseAndSanitizeCLIArgs(networkArgs);
   await validateStartAndEndBlocks(networks);

--- a/backend/buildBackfill.ts
+++ b/backend/buildBackfill.ts
@@ -1,0 +1,382 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import {
+  Address,
+  createPublicClient,
+  getAddress,
+  http,
+  parseAbi,
+  parseAbiItem,
+  PublicClient,
+} from "viem";
+import { polygon } from "viem/chains";
+import { ChainId, config } from "./config";
+import { IncentivesJson } from "./safeTxArrayBuilder";
+
+/**
+ * Builds the one-time `TANIssuanceHistory::backfillCumulativeRewards` payload.
+ *
+ * A redeployed `TANIssuanceHistory` starts with no reward history, which would reset every wallet's
+ * reward cap to its full stake. This script reads each wallet's lifetime cumulative rewards from the
+ * predecessor contract, rescales them into the V3 reward token's decimals, and emits Safe UI chunks.
+ *
+ * Usage:
+ *   yarn ts-node backend/buildBackfill.ts --cutover-block <n> [--scan-from <n>] [--skip-onchain-check]
+ *
+ * The emitted amounts are already rescaled; the contract stores whatever it is given.
+ */
+
+/// Legacy TEL carries 2 decimals and TelcoinV3 carries 18, so every carried-over balance scales up.
+const LEGACY_TEL_DECIMALS = 2n;
+const DECIMAL_RESCALE = 10n ** (18n - LEGACY_TEL_DECIMALS);
+
+/// Matches the chunk size the Safe UI settlement flow already uses.
+const CHUNK_SIZE = 300;
+
+/// Addresses per `cumulativeRewardsAtBlockBatched` call. The getter loops, so keep calls modest.
+const READ_BATCH_SIZE = 200;
+
+/// Only whole period files count. Reruns duplicate a period and would double count.
+const PERIOD_FILE_PATTERN = /^staker_rewards_period_(\d+)\.json$/;
+
+const legacyHistoryAbi = parseAbi([
+  "function cumulativeRewardsAtBlockBatched(address[] accounts, uint256 queryBlock) view returns (address[], uint256[])",
+  "function lastSettlementBlock() view returns (uint256)",
+]);
+
+/// The predecessor plugin emits the pre- and post-credit balances rather than the delta.
+const legacyClaimableIncreased = parseAbiItem(
+  "event ClaimableIncreased(address indexed account, uint256 oldClaimable, uint256 newClaimable)",
+);
+
+type Deployments = {
+  TANIssuanceHistory: Address;
+  TANIssuancePlugin: Address;
+};
+
+type CliArgs = {
+  cutoverBlock: bigint;
+  scanFrom?: bigint;
+  skipOnchainCheck: boolean;
+};
+
+async function main() {
+  const { cutoverBlock, scanFrom, skipOnchainCheck } = parseCliArgs();
+
+  const deployments = await readDeployments();
+  const legacyHistory = getAddress(deployments.TANIssuanceHistory);
+  const legacyPlugin = getAddress(deployments.TANIssuancePlugin);
+
+  const client = createPublicClient({
+    batch: { multicall: true },
+    chain: polygon,
+    transport: http(config.rpcUrls[ChainId.Polygon], { batch: true }),
+  }) as PublicClient;
+
+  const latestBlock = await client.getBlockNumber();
+  if (cutoverBlock > latestBlock) {
+    throw new Error(
+      `--cutover-block ${cutoverBlock} is ahead of chain head ${latestBlock}`,
+    );
+  }
+
+  // 1. Every wallet that has ever been settled a TAN reward, per the published period files.
+  const { recipients, sumFromFiles, periods, earliestStartBlock } =
+    await readRecipientsFromFiles();
+  console.log(
+    `Read ${periods.length} period files (${periods[0]}..${
+      periods[periods.length - 1]
+    }): ${recipients.size} distinct recipients, ${sumFromFiles} total legacy TEL`,
+  );
+
+  // 2. Independent completeness check straight from the chain. The predecessor history contract is
+  //    the plugin's only increaser, so these logs are exactly the TAN recipient set.
+  let sumFromLogs: bigint | undefined;
+  if (skipOnchainCheck) {
+    console.warn(
+      "WARNING: --skip-onchain-check passed. The recipient set is not verified against chain logs.",
+    );
+  } else {
+    // the first period's start block is the earliest any settlement can have landed
+    const fromBlock = scanFrom ?? earliestStartBlock;
+    console.log(
+      `Scanning ${legacyPlugin} ClaimableIncreased logs over [${fromBlock}, ${cutoverBlock}]...`,
+    );
+    const onchain = await readClaimableIncreased(
+      client,
+      legacyPlugin,
+      fromBlock,
+      cutoverBlock,
+    );
+    sumFromLogs = onchain.total;
+
+    const missing = [...onchain.accounts].filter(
+      (account) => !recipients.has(account),
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `${missing.length} account(s) were credited onchain but are absent from the period files, ` +
+          `so the backfill would silently drop them. First few: ${missing
+            .slice(0, 5)
+            .join(", ")}. Widen --scan-from or reconcile the rewards files before proceeding.`,
+      );
+    }
+    console.log(
+      `Onchain logs: ${onchain.accounts.size} distinct accounts, ${onchain.total} total legacy TEL`,
+    );
+  }
+
+  // 3. Authoritative per-account values, read from the predecessor's own getter at the cutover.
+  const accounts = [...recipients].sort();
+  const cumulative = await readCumulativeRewards(
+    client,
+    legacyHistory,
+    accounts,
+    cutoverBlock,
+  );
+
+  // 4. Reconcile all three sources before emitting anything.
+  const sumFromGetter = [...cumulative.values()].reduce((a, b) => a + b, 0n);
+  console.log(
+    `\nReconciliation (legacy TEL, ${LEGACY_TEL_DECIMALS} decimals):\n` +
+      `  period files : ${sumFromFiles}\n` +
+      `  onchain logs : ${sumFromLogs ?? "(skipped)"}\n` +
+      `  history getter: ${sumFromGetter}`,
+  );
+  if (sumFromGetter !== sumFromFiles) {
+    throw new Error(
+      `Reconciliation failed: the predecessor reports ${sumFromGetter} cumulative TEL but the ` +
+        `period files sum to ${sumFromFiles}. Resolve before backfilling.`,
+    );
+  }
+  if (sumFromLogs !== undefined && sumFromLogs !== sumFromGetter) {
+    throw new Error(
+      `Reconciliation failed: onchain credits sum to ${sumFromLogs} but the predecessor reports ` +
+        `${sumFromGetter}. Resolve before backfilling.`,
+    );
+  }
+  console.log("All sources agree.");
+
+  // 5. Rescale into the V3 reward token's decimals and emit Safe chunks.
+  const entries: Array<[Address, bigint]> = accounts
+    .map((account): [Address, bigint] => [
+      account,
+      (cumulative.get(account) ?? 0n) * DECIMAL_RESCALE,
+    ])
+    // a zero row is skipped by the contract, so leave it out of the payload entirely
+    .filter(([, amount]) => amount > 0n);
+
+  const rescaledTotal = entries.reduce((sum, [, amount]) => sum + amount, 0n);
+  console.log(
+    `\nBackfilling ${entries.length} accounts, ${rescaledTotal} total (18 decimals).`,
+  );
+
+  await writeChunks(entries, cutoverBlock, legacyHistory);
+}
+
+/**
+ * Reads every published period file and returns the union of recipients plus the total settled.
+ */
+async function readRecipientsFromFiles(): Promise<{
+  recipients: Set<Address>;
+  sumFromFiles: bigint;
+  periods: number[];
+  earliestStartBlock: bigint;
+}> {
+  const rewardsDir = path.join(__dirname, "..", "rewards");
+  const files = (await fs.readdir(rewardsDir)).filter((file) =>
+    PERIOD_FILE_PATTERN.test(file),
+  );
+  if (files.length === 0) {
+    throw new Error(`No period files found in ${rewardsDir}`);
+  }
+
+  const recipients = new Set<Address>();
+  const periods: number[] = [];
+  let sumFromFiles = 0n;
+  let earliestStartBlock: bigint | undefined;
+
+  for (const file of files) {
+    periods.push(Number(PERIOD_FILE_PATTERN.exec(file)![1]));
+
+    const raw = await fs.readFile(path.join(rewardsDir, file), "utf-8");
+    const parsed = JSON.parse(raw) as IncentivesJson;
+    for (const incentive of parsed.stakerIncentives) {
+      const reward = BigInt(incentive.reward);
+      if (reward === 0n) continue;
+
+      recipients.add(getAddress(incentive.address));
+      sumFromFiles += reward;
+    }
+
+    for (const range of parsed.blockRanges) {
+      if (range.network !== "polygon") continue;
+
+      const startBlock = BigInt(range.startBlock);
+      if (earliestStartBlock === undefined || startBlock < earliestStartBlock) {
+        earliestStartBlock = startBlock;
+      }
+    }
+  }
+
+  if (earliestStartBlock === undefined) {
+    throw new Error(
+      "No polygon block range found across the period files, so the log scan floor is unknown. " +
+        "Pass --scan-from explicitly.",
+    );
+  }
+
+  periods.sort((a, b) => a - b);
+  return { recipients, sumFromFiles, periods, earliestStartBlock };
+}
+
+/**
+ * Collects every account credited on the predecessor plugin, and the total credited.
+ *
+ * @dev The block range is split adaptively: a range that a provider rejects (log cap or range cap)
+ * is halved and retried, so this works across providers without tuning a chunk size.
+ */
+async function readClaimableIncreased(
+  client: PublicClient,
+  plugin: Address,
+  fromBlock: bigint,
+  toBlock: bigint,
+): Promise<{ accounts: Set<Address>; total: bigint }> {
+  const accounts = new Set<Address>();
+  let total = 0n;
+
+  const scan = async (from: bigint, to: bigint): Promise<void> => {
+    try {
+      const logs = await client.getLogs({
+        address: plugin,
+        event: legacyClaimableIncreased,
+        fromBlock: from,
+        toBlock: to,
+      });
+
+      for (const log of logs) {
+        accounts.add(getAddress(log.args.account!));
+        total += log.args.newClaimable! - log.args.oldClaimable!;
+      }
+    } catch (err) {
+      if (from >= to) throw err;
+
+      const mid = from + (to - from) / 2n;
+      await scan(from, mid);
+      await scan(mid + 1n, to);
+    }
+  };
+
+  await scan(fromBlock, toBlock);
+  return { accounts, total };
+}
+
+/**
+ * Reads each account's lifetime cumulative rewards from the predecessor contract at `queryBlock`.
+ */
+async function readCumulativeRewards(
+  client: PublicClient,
+  legacyHistory: Address,
+  accounts: Address[],
+  queryBlock: bigint,
+): Promise<Map<Address, bigint>> {
+  const cumulative = new Map<Address, bigint>();
+
+  for (let i = 0; i < accounts.length; i += READ_BATCH_SIZE) {
+    const batch = accounts.slice(i, i + READ_BATCH_SIZE);
+    const [returnedAccounts, rewards] = await client.readContract({
+      address: legacyHistory,
+      abi: legacyHistoryAbi,
+      functionName: "cumulativeRewardsAtBlockBatched",
+      args: [batch, queryBlock],
+    });
+
+    returnedAccounts.forEach((account, j) => {
+      cumulative.set(getAddress(account), rewards[j]);
+    });
+  }
+
+  return cumulative;
+}
+
+/**
+ * Writes the payload as Safe UI chunks, one file per `backfillCumulativeRewards` transaction.
+ */
+async function writeChunks(
+  entries: Array<[Address, bigint]>,
+  cutoverBlock: bigint,
+  legacyHistory: Address,
+) {
+  const outputDir = path.join(__dirname, "temp");
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const chunkCount = Math.ceil(entries.length / CHUNK_SIZE);
+  for (let i = 0; i < chunkCount; i++) {
+    const chunk = entries.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
+    // shaped for `backfillCumulativeRewards(address[], uint256[], uint256)`
+    const payload = [
+      chunk.map(([account]) => account),
+      chunk.map(([, amount]) => amount.toString()),
+    ];
+
+    const outputFilePath = path.join(
+      outputDir,
+      `safe_param_backfill_chunk_${i}.json`,
+    );
+    await fs.writeFile(outputFilePath, JSON.stringify(payload, null, 2));
+    console.log(`  chunk ${i} (${chunk.length} accounts) -> ${outputFilePath}`);
+  }
+
+  console.log(
+    `\nSubmit each chunk to TANIssuanceHistory::backfillCumulativeRewards(address[], uint256[], uint256)\n` +
+      `  atBlock: ${cutoverBlock}\n` +
+      `  source : ${legacyHistory}\n` +
+      `Chunks are order independent and safe to retry; an account that already carries history is skipped.\n` +
+      `Once every chunk has landed and been spot checked, call sealBackfill() to close the path.`,
+  );
+}
+
+async function readDeployments(): Promise<Deployments> {
+  const raw = await fs.readFile(
+    path.join(__dirname, "..", "deployments", "deployments.json"),
+    "utf-8",
+  );
+
+  return JSON.parse(raw) as Deployments;
+}
+
+function parseCliArgs(): CliArgs {
+  const args = process.argv.slice(2);
+
+  const readBigInt = (flag: string): bigint | undefined => {
+    const index = args.indexOf(flag);
+    if (index === -1) return undefined;
+    if (index + 1 >= args.length) {
+      throw new Error(`${flag} must be followed by a block number`);
+    }
+
+    return BigInt(args[index + 1]);
+  };
+
+  const cutoverBlock = readBigInt("--cutover-block");
+  if (cutoverBlock === undefined) {
+    throw new Error(
+      "--cutover-block is required. Use the block the V3 system goes live at; it becomes the " +
+        "new contract's lastSettlementBlock and the key every seeded checkpoint is written under.",
+    );
+  }
+
+  return {
+    cutoverBlock,
+    scanFrom: readBigInt("--scan-from"),
+    skipOnchainCheck: args.includes("--skip-onchain-check"),
+  };
+}
+
+main().catch((err) => {
+  console.error("\nBackfill build failed:", err.message ?? err);
+  process.exit(1);
+});

--- a/backend/calculators/DeveloperIncentivesCalculator.ts
+++ b/backend/calculators/DeveloperIncentivesCalculator.ts
@@ -12,7 +12,7 @@ import {
   scaleDecimals,
   unorderedArraysEqual,
 } from "../helpers";
-import { ChainId, config } from "../config";
+import { ChainId, config, telTokenFor } from "../config";
 
 /**
  * This class calculates TAN developers' referrals incentives.
@@ -60,7 +60,7 @@ export class DeveloperIncentivesCalculator implements ICalculator<bigint> {
    * @dev Then fetches all executors' transactions within `[startBlock:endBlock]` range
    * @dev Maps each executor address to its `Transaction`s
    * @dev Also maps each `Transaction` hash to its executor address (`== tx.origin`)
-   * @dev Fetches `SimplePlugin::claimableIncreased` events to get referrals and amounts (`newClaimable - oldClaimable`)
+   * @dev Fetches `SimplePlugin::ClaimableIncreased` events, which carry the credited amount directly
    * @dev Finally maps each developer to its number of referrals
    * @returns `referralsPerDeveloper` Intended to be passed to `calculateIncentivesFromVolumeOrSimilar()`
    */
@@ -113,8 +113,8 @@ export class DeveloperIncentivesCalculator implements ICalculator<bigint> {
       // process each event to identify claimable amount delta in referrals
       for (const event of claimableIncreasedEvents) {
         const amount = scaleDecimals(
-          event.newClaimable - event.oldClaimable,
-          config.telToken[plugin.chain].decimals,
+          event.amount,
+          telTokenFor(plugin.chain).decimals,
           config.canonicalDecimals
         );
 

--- a/backend/calculators/StakerIncentivesCalculator.ts
+++ b/backend/calculators/StakerIncentivesCalculator.ts
@@ -149,6 +149,18 @@ export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> 
     console.log("Fetching UserFeeTransfers...");
     const userFeeTransfers = await this.fetchUserFeeTransfers();
 
+    // A settled period always has user fees. Finding none means the inputs are wrong rather than
+    // the week being quiet: the wrong TEL token is configured for the chain, the AmirX set is
+    // stale, or the block range is. Left unchecked this publishes an empty reward file with no
+    // error, so refuse to produce a distribution off it.
+    if (userFeeTransfers.length === 0) {
+      throw new Error(
+        "No user fee transfers found for this period. Check that config.telToken matches the token " +
+          "AmirX actually collects fees in, that data/amirXs.ts is current, and that the block range " +
+          "is correct.",
+      );
+    }
+
     console.log("Fetching onchain data for eligible (staked) users");
     const [eligibleStakerSwaps, addressToRewardDatas] =
       await this.fetchOnchainData(userFeeTransfers);

--- a/backend/calculators/StakerIncentivesCalculator.ts
+++ b/backend/calculators/StakerIncentivesCalculator.ts
@@ -1,10 +1,7 @@
 import {
-  AbiEvent,
   Address,
   decodeFunctionData,
-  getAbiItem,
   getAddress,
-  GetLogsReturnType,
   PublicClient,
   zeroAddress,
 } from "viem";
@@ -49,11 +46,16 @@ type OnchainRewardData = {
   prevCumulativeRewards: bigint;
 };
 
-export type StakeChangedEvent = {
-  account: Address;
+/**
+ * A single entry of an account's sTEL vote history on the StakingModule.
+ *
+ * `StakingModule` is an `ERC20Votes` token that auto-self-delegates on first receipt, so an
+ * account's votes track its staked balance and `votes` is the balance in effect from
+ * `blockNumber` onward, until the next checkpoint.
+ */
+export type VoteCheckpoint = {
   blockNumber: bigint;
-  oldStake: bigint;
-  newStake: bigint;
+  votes: bigint;
 };
 
 export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> {
@@ -255,7 +257,6 @@ export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> 
   ): Promise<[UserFeeSwap[], Map<Address, OnchainRewardData[]>]> {
     const addressToOnchainRewardDatas = new Map<Address, OnchainRewardData[]>();
 
-    // note that this entire block could be replaced with a solidity checkpoint reading function on the StakingModule
     let eligibleUserFeeSwaps: UserFeeSwap[][] = await Promise.all(
       // map over all chains, delineated by staking modules
       this._stakingModules.map(async (currentChainStakingModule) => {
@@ -273,37 +274,24 @@ export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> 
           (issuanceHistory) => issuanceHistory.chain === currentChain,
         );
 
-        // fetch `StakingModule::StakeChanged()` events to identify lowest stake balance during period and update rewardDatas
-        const stakeChangedAbiItem = getAbiItem({
-          abi: currentChainStakingModule.abi,
-          name: "StakeChanged",
-        });
-        // create set to filter stake changed events for those including users or referrers
+        // every account that appears in a swap, as either the wallet or the referrer
         const accountsOfInterest = new Set<Address>();
         userFeeSwaps.map((swap) => {
           accountsOfInterest.add(swap.userAddress);
         });
+        accountsOfInterest.delete(zeroAddress);
 
-        const stakeChangedEvents = await this.fetchStakeChangedEvents(
+        const accountToAverageStake = await this.calculateAvgStakedAmountsPerAccount(
           client,
           currentChainStakingModule.address,
-          stakeChangedAbiItem as AbiEvent,
-          { account: Array.from(accountsOfInterest) },
+          Array.from(accountsOfInterest),
           this._startBlocks[currentChain]!,
           this._endBlocks[currentChain]!,
         );
 
-        const accountToAverageStake =
-          await this.CalculateAvgStakedAmountsPerAccount(
-            stakeChangedEvents,
-            this._startBlocks[currentChain]!,
-            this._endBlocks[currentChain]!,
-          );
-
         return await this.processUserFeeSwaps(
           userFeeSwaps,
           client,
-          currentChainStakingModule.address,
           currentChainTanIssuanceHistory!.address,
           addressToOnchainRewardDatas,
           accountToAverageStake,
@@ -314,66 +302,127 @@ export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> 
     return [eligibleUserFeeSwaps.flat(), addressToOnchainRewardDatas];
   }
 
-  async CalculateAvgStakedAmountsPerAccount(
-    stakeChangedEvents: StakeChangedEvent[],
+  /**
+   * @dev Reads each account's full sTEL vote checkpoint history from the StakingModule and reduces it
+   * to a duration-weighted average stake over `[fromBlock, toBlock]`.
+   *
+   * The StakingModule keeps these checkpoints as contract storage, so this reads the same source
+   * `getPastVotes` resolves against rather than replaying logs. That avoids provider log-range
+   * limits entirely, and it means every account is measured the same way whether or not its stake
+   * happened to move during the period.
+   *
+   * @returns A map of account to its duration-weighted average stake. Accounts that held nothing
+   * across the whole period map to `0n`.
+   */
+  async calculateAvgStakedAmountsPerAccount(
+    client: PublicClient,
+    stakingModule: Address,
+    accounts: Address[],
     fromBlock: bigint,
     toBlock: bigint,
   ): Promise<Map<Address, bigint>> {
-    // populate a map of Address => newStakeAmount which will be used to skip RPC calls to `StakingModule::stakedByAt()`
-    const accountToLowestStake = new Map<Address, bigint>();
+    const accountToAverageStake = new Map<Address, bigint>();
 
-    // Group stakeChangedEvents by their `args.account`
-    const groupedStakeChangedEvents = stakeChangedEvents.reduce(
-      (grouped, event) => {
-        if (!grouped.has(event.account)) {
-          grouped.set(event.account, []);
-        }
-        grouped.get(event.account)!.push(event);
-        return grouped;
-      },
-      new Map<Address, typeof stakeChangedEvents>(),
+    const histories = await Promise.all(
+      accounts.map((account) =>
+        this.fetchVoteCheckpoints(client, account, stakingModule),
+      ),
     );
 
-    // Loop over the grouping and log account and its corresponding events
-    groupedStakeChangedEvents.forEach((events, account) => {
-      events.sort((a, b) => (a.blockNumber > b.blockNumber ? 1 : -1));
-
-      let lowestBlockNumber = fromBlock;
-
-      const stakedAmount: { blocks: bigint; stake: bigint }[] = [];
-      for (let i = 0; i < events.length; i++) {
-        stakedAmount.push({
-          blocks: events[i].blockNumber - lowestBlockNumber!,
-          stake: events[i].oldStake,
-        });
-
-        if (i == events.length - 1) {
-          stakedAmount.push({
-            blocks: toBlock! - events[i].blockNumber,
-            stake: events[i].newStake,
-          });
-        }
-
-        lowestBlockNumber = events[i].blockNumber;
-      }
-
-      // calculate the total number of blocks available in our period here.
-      const totalBlocks = (toBlock ?? 0n) - (fromBlock ?? 0n);
-
-      // Calculate the total staked amount weighted by the duration for each stake period
-      let totalWeightedStake = 0n;
-
-      stakedAmount.forEach(({ blocks, stake }) => {
-        totalWeightedStake += stake * blocks;
-      });
-
-      // Calculate the average stake over the total duration and total blocks
-      const averageStakeOverTime = totalWeightedStake / totalBlocks;
-
-      accountToLowestStake.set(account, averageStakeOverTime);
+    accounts.forEach((account, i) => {
+      accountToAverageStake.set(
+        account,
+        this.durationWeightedStake(histories[i], fromBlock, toBlock),
+      );
     });
 
-    return accountToLowestStake;
+    return accountToAverageStake;
+  }
+
+  /**
+   * @dev Reduces a checkpoint history to the average stake held across `[fromBlock, toBlock]`,
+   * weighting each stake level by the number of blocks it was in effect for.
+   *
+   * A checkpoint at block `k` with value `v` means the account held `v` from block `k` onward, so
+   * the opening balance is the newest checkpoint at or before `fromBlock`, and checkpoints after
+   * `toBlock` are ignored.
+   */
+  durationWeightedStake(
+    checkpoints: VoteCheckpoint[],
+    fromBlock: bigint,
+    toBlock: bigint,
+  ): bigint {
+    const ordered = [...checkpoints].sort((a, b) =>
+      a.blockNumber === b.blockNumber
+        ? 0
+        : a.blockNumber < b.blockNumber
+          ? -1
+          : 1,
+    );
+
+    // stake in effect at the start of the period
+    let currentStake = 0n;
+    for (const checkpoint of ordered) {
+      if (checkpoint.blockNumber > fromBlock) break;
+      currentStake = checkpoint.votes;
+    }
+
+    const totalBlocks = toBlock - fromBlock;
+    // a single-block period has no duration to weight by, so the opening balance is the answer
+    if (totalBlocks <= 0n) return currentStake;
+
+    let totalWeightedStake = 0n;
+    let cursor = fromBlock;
+    for (const checkpoint of ordered) {
+      if (checkpoint.blockNumber <= fromBlock) continue;
+      if (checkpoint.blockNumber > toBlock) break;
+
+      totalWeightedStake += currentStake * (checkpoint.blockNumber - cursor);
+      currentStake = checkpoint.votes;
+      cursor = checkpoint.blockNumber;
+    }
+    totalWeightedStake += currentStake * (toBlock - cursor);
+
+    return totalWeightedStake / totalBlocks;
+  }
+
+  /**
+   * @dev Reads every sTEL vote checkpoint recorded for `account`.
+   *
+   * `numCheckpoints` and `checkpoints` are the standard `ERC20Votes` accessors. The client batches
+   * concurrent reads into multicalls, so the per-entry reads collapse into a small number of
+   * requests.
+   */
+  async fetchVoteCheckpoints(
+    client: PublicClient,
+    account: Address,
+    stakingModule: Address,
+  ): Promise<VoteCheckpoint[]> {
+    // A failed read must not be reported as "no stake". That would silently drop the account's
+    // reward cap to zero and pay it nothing, so let the error abort the period instead.
+    const numCheckpoints = await client.readContract({
+      address: stakingModule,
+      abi: StakingModuleAbi,
+      functionName: "numCheckpoints",
+      args: [account],
+    });
+
+    const positions = Array.from({ length: Number(numCheckpoints) }, (_, i) => i);
+    const checkpoints = await Promise.all(
+      positions.map((pos) =>
+        client.readContract({
+          address: stakingModule,
+          abi: StakingModuleAbi,
+          functionName: "checkpoints",
+          args: [account, pos],
+        }),
+      ),
+    );
+
+    return checkpoints.map((checkpoint) => ({
+      blockNumber: BigInt(checkpoint._key),
+      votes: BigInt(checkpoint._value),
+    }));
   }
 
   /**
@@ -384,7 +433,6 @@ export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> 
   private async processUserFeeSwaps(
     userFeeSwaps: UserFeeSwap[],
     client: PublicClient,
-    stakingModuleContract: Address,
     tanIssuanceHistory: Address,
     addressToOnchainRewardDatas: Map<Address, OnchainRewardData[]>,
     accountToAverageStake: Map<Address, bigint>,
@@ -405,7 +453,6 @@ export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> 
         const userEligible = await this.processAddress(
           userFeeSwap.userAddress,
           client,
-          stakingModuleContract,
           tanIssuanceHistory,
           addressToOnchainRewardDatas,
           accountToAverageStake,
@@ -420,15 +467,13 @@ export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> 
 
   /**
    * @returns True if the `UserFeeSwap` user is eligible for rewards and was successfully processed; else false
-   * @dev Checks whether onchain data, ie stake and cumulative rewards, has already been fetched for given `address`
-   * If not, cross reference `address` against known stake changes previously detected from `StakeChanged` events
-   * If a change in stake for `address` was emitted, stake is known so only fetch cumulative rewards and return true
-   * If no stake change was emitted, fetch the stake. If 0, return false. If > 0, fetch cumulative rewards and return true
+   * @dev An account is eligible when it held stake at some point during the period, which is exactly
+   * when its duration-weighted average stake is nonzero. That average is already known for every
+   * account of interest, so the only remaining read is the account's prior cumulative rewards.
    */
   private async processAddress(
     address: Address,
     client: PublicClient,
-    stakingModuleContract: Address,
     tanIssuanceHistory: Address,
     addressToOnchainRewardDatas: Map<Address, OnchainRewardData[]>,
     accountToAverageStake: Map<Address, bigint>,
@@ -447,68 +492,29 @@ export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> 
       return true;
     }
 
-    // query `TANIssuanceHistory` contract with period's start block so runs on settled periods
-    // return cumulative rewards for this period's pre-settlement value and not the next period's
+    const averageStake = accountToAverageStake.get(address) ?? 0n;
+    // ignore addresses that are not staked; they are not eligible so their cumulative rewards are irrelevant
+    if (averageStake === 0n) return false;
+
+    // query `TANIssuanceHistory` one block before the period ends so that re-running a settled period
+    // returns this period's pre-settlement value rather than the next period's
     const currentChainEndBlock = this._endBlocks[chainId]! - 1n;
-    const existingAverageStake = accountToAverageStake.get(address);
-    // check whether the account's lowest stake for the period was detected from `StakeChanged` events
-    if (existingAverageStake) {
-      // if nonzero lowest stake was identified by `StakeChanged` events, only fetch cumulative rewards
-      const prevCumulativeRewards = await this.fetchCumulativeRewardsAtBlock(
-        client,
-        address,
-        currentChainEndBlock,
-        tanIssuanceHistory,
-      );
-      addressToOnchainRewardDatas.set(address, [
-        {
-          chain: chainId,
-          userStake: existingAverageStake!,
-          prevCumulativeRewards: prevCumulativeRewards,
-        },
-      ]);
+    const prevCumulativeRewards = await this.fetchCumulativeRewardsAtBlock(
+      client,
+      address,
+      currentChainEndBlock,
+      tanIssuanceHistory,
+    );
+    addressToOnchainRewardDatas.set(address, [
+      {
+        chain: chainId,
+        userStake: averageStake,
+        prevCumulativeRewards: prevCumulativeRewards,
+      },
+    ]);
 
-      // no more RPC calls necessary when the account's lowest stake was discerned from `StakeChanged` events
-      // in which case this function is being invoked for a `UserFeeSwap` that should be processed
-      return true;
-    } else {
-      // account's stake did not emit a change event during the period so it must be fetched
-      console.log(
-        `No StakeChanged events during period for ${address}, fetching from StakingModule`,
-      );
-      const stake = await this.fetchStake(
-        client,
-        address,
-        currentChainEndBlock,
-        stakingModuleContract,
-      );
-
-      // ignore addresses that are not staked; they are not eligible so their cumulative rewards are irrelevant
-      if (stake !== 0n) {
-        console.log(
-          `Nonzero stake returned for ${address}: ${stake} TEL, fetching cumulative rewards`,
-        );
-        const prevCumulativeRewards = await this.fetchCumulativeRewardsAtBlock(
-          client,
-          address,
-          currentChainEndBlock,
-          tanIssuanceHistory,
-        );
-        addressToOnchainRewardDatas.set(address, [
-          {
-            chain: chainId,
-            userStake: stake,
-            prevCumulativeRewards: prevCumulativeRewards,
-          },
-        ]);
-
-        // address is eligible (ie staked) and has been processed (ie added to `addressToOnchainRewardDatas`)
-        return true;
-      }
-    }
-
-    // address did not meet eligibility criteria
-    return false;
+    // address is eligible (ie staked) and has been processed (ie added to `addressToOnchainRewardDatas`)
+    return true;
   }
 
   /**
@@ -595,89 +601,20 @@ export class StakerIncentivesCalculator implements ICalculator<UserRewardEntry> 
     stakerFeeTotalsMap.set(address, feeTotals);
   }
 
-  async fetchStakeChangedEvents(
-    client: PublicClient,
-    stakingModuleAddress: Address,
-    stakeChangedEvent: AbiEvent,
-    args: { account: Address[] },
-    startBlock: bigint,
-    endBlock: bigint,
-  ): Promise<StakeChangedEvent[]> {
-    const loggedEvents: GetLogsReturnType<
-      AbiEvent,
-      [AbiEvent],
-      undefined,
-      bigint | undefined,
-      bigint | undefined
-    > = await client.getLogs({
-      address: stakingModuleAddress,
-      event: stakeChangedEvent,
-      args: args,
-      fromBlock: startBlock,
-      toBlock: endBlock,
-    });
-
-    return loggedEvents.map((event) => {
-      const { account, oldStake, newStake } = event.args as {
-        account: Address;
-        oldStake: bigint;
-        newStake: bigint;
-      };
-
-      return {
-        blockNumber: event.blockNumber,
-        account: account,
-        oldStake: oldStake,
-        newStake: newStake,
-      } as StakeChangedEvent;
-    });
-  }
-
-  async fetchStake(
-    client: PublicClient,
-    userAddress: Address,
-    endBlock: bigint,
-    stakingModule: Address,
-  ): Promise<bigint> {
-    try {
-      const currentlyStaked = await client.readContract({
-        address: stakingModule,
-        abi: StakingModuleAbi,
-        functionName: "stakedByAt",
-        args: [userAddress, endBlock],
-      });
-
-      return currentlyStaked;
-    } catch (err) {
-      // log error to console but don't panic at this point
-      console.error(`Error fetching stake for user ${userAddress}`, err);
-      return 0n;
-    }
-  }
-
   async fetchCumulativeRewardsAtBlock(
     client: PublicClient,
     userAddress: Address,
     endBlock: bigint,
     tanIssuanceHistory: Address,
   ): Promise<bigint> {
-    try {
-      const prevCumulativeRewards = await client.readContract({
-        address: tanIssuanceHistory,
-        abi: TanIssuanceHistoryAbi,
-        functionName: "cumulativeRewardsAtBlock",
-        args: [userAddress, endBlock],
-      });
-
-      return prevCumulativeRewards;
-    } catch (err) {
-      // log error to console but don't panic at this point
-      console.error(
-        `Error fetching cumulativeRewards for user ${userAddress} at block ${endBlock}`,
-        err,
-      );
-      return 0n;
-    }
+    // A failed read must not be reported as zero prior rewards. That would lift the account's reward
+    // cap to its full stake and overpay it, so let the error abort the period instead.
+    return await client.readContract({
+      address: tanIssuanceHistory,
+      abi: TanIssuanceHistoryAbi,
+      functionName: "cumulativeRewardsAtBlock",
+      args: [userAddress, endBlock],
+    });
   }
 
   /**

--- a/backend/config.ts
+++ b/backend/config.ts
@@ -1,8 +1,16 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 
-import { Address, getAddress } from "viem";
+import { Address, getAddress, zeroAddress } from "viem";
 import { base, mainnet, polygon } from "viem/chains";
+
+/**
+ * TelcoinV3 on Polygon, the reward token TAN issuance settles in after the V3 cutover.
+ *
+ * TODO: fill in once TelcoinV3 is deployed to Polygon. `assertTelTokensConfigured` rejects a period
+ * run while this is unset, so an unconfigured value cannot silently produce an empty reward set.
+ */
+const POLYGON_TEL_V3: Address = zeroAddress;
 
 // TODO: add Telcoin Network to the list of supported chains and to the ChainId enum
 // see: https://viem.sh/docs/clients/chains.html#build-your-own
@@ -33,7 +41,8 @@ export const config = {
   incentivesAmounts: {
     telcoinNetworkGasFeesIncentivesAmount: 100000000n,
     developerIncentivesAmount: 100000000n,
-    stakerIncentivesAmount: 320512820n,
+    // 3,205,128.20 TEL per period, denominated in the 18-decimal reward token
+    stakerIncentivesAmount: 320512820n * 10n ** 16n,
   },
   simplePlugins: {
     // list of SimplePlugins, for use with the DeveloperIncentivesCalculator
@@ -57,8 +66,8 @@ export const config = {
   },
   telToken: {
     [ChainId.Polygon]: {
-      address: getAddress("0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32"),
-      decimals: 2n,
+      address: POLYGON_TEL_V3,
+      decimals: 18n,
       chain: ChainId.Polygon,
     },
     [ChainId.Mainnet]: {
@@ -71,7 +80,39 @@ export const config = {
       address: getAddress(""), // use WTEL
       decimals: 2n,
       chain: ChainId.TelcoinNetwork,
-    }, 
+    },
    */
   },
 } as const;
+
+/**
+ * The TEL token for a chain, or a thrown error if that chain has none configured.
+ *
+ * `ChainId` covers more chains than TEL is deployed on, so indexing `config.telToken` directly with
+ * an arbitrary `ChainId` is not type-safe.
+ */
+export function telTokenFor(chain: ChainId): Token {
+  const token = (config.telToken as Partial<Record<ChainId, Token>>)[chain];
+  if (token === undefined) {
+    throw new Error(`No TEL token is configured for chain ${chain}`);
+  }
+
+  return token;
+}
+
+/**
+ * Throws unless every configured TEL token has a real address behind it.
+ *
+ * Called at the start of a period run so that an unconfigured deployment fails immediately rather
+ * than silently matching zero transfers and producing an empty reward set.
+ */
+export function assertTelTokensConfigured(): void {
+  for (const token of Object.values(config.telToken) as Token[]) {
+    if (token.address === zeroAddress) {
+      throw new Error(
+        `TEL token address for chain ${token.chain} is unset. ` +
+          `Populate it in backend/config.ts from the deployment before running a period.`,
+      );
+    }
+  }
+}

--- a/backend/datasources/SimplePlugin.ts
+++ b/backend/datasources/SimplePlugin.ts
@@ -15,8 +15,8 @@ import { mainnet, polygon } from "viem/chains";
 export type ClaimableIncreasedEvent = {
   txHash: Hash;
   account: Address;
-  oldClaimable: bigint;
-  newClaimable: bigint;
+  /// The amount credited by this event, denominated in the plugin's reward token.
+  amount: bigint;
 };
 
 /**
@@ -110,8 +110,7 @@ export class SimplePlugin extends BaseSimplePlugin {
     return logs.map((log) => ({
       txHash: log.transactionHash!,
       account: getAddress(log.args.account!),
-      oldClaimable: log.args.oldClaimable!,
-      newClaimable: log.args.newClaimable!,
+      amount: log.args.amount!,
     }));
   }
 }

--- a/backend/test/DeveloperIncentivesCalculator.test.ts
+++ b/backend/test/DeveloperIncentivesCalculator.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../datasources/ExecutorRegistry";
 import { BaseBlocksDatabase } from "../datasources/persistent/BlocksDatabase";
 import { readFileSync } from "fs";
-import { ChainId, config } from "../config";
+import { ChainId, config, telTokenFor } from "../config";
 import {
   BaseSimplePlugin,
   ClaimableIncreasedEvent,
@@ -56,8 +56,14 @@ class FakeSimplePlugin extends BaseSimplePlugin {
   }
 }
 
+// a SimplePlugin can only exist on a chain TEL is deployed to, so restrict generated plugins to
+// those chains and keep reward amounts denominated in something
+const telChains = config.chains
+  .map((chain) => chain.id as ChainId)
+  .filter((chain) => chain in config.telToken);
+
 function randomChainId(): ChainId {
-  return config.chains[Math.floor(Math.random() * config.chains.length)].id;
+  return telChains[Math.floor(Math.random() * telChains.length)];
 }
 
 function randomHex(bytes: number): `0x${string}` {
@@ -102,9 +108,10 @@ async function generateFakeData(
   executorRegistry.setExecutors(executors);
 
   // generate fake blocks dbs (and set a fake block #1 in rpc)
+  // one database per TEL chain, matching the start/end block maps the calculator is constructed with
   const blocksDbs: FakeBlocksDatabase[] = [];
-  for (const chain of config.chains) {
-    const db = new FakeBlocksDatabase(chain.id);
+  for (const chain of telChains) {
+    const db = new FakeBlocksDatabase(chain);
 
     db._rpc.set(1n, copyByJson(blockTemplate));
 
@@ -120,13 +127,11 @@ async function generateFakeData(
     simplePlugins.push(plugin);
 
     for (let j = 0; j < nEventsPerPlugin; j++) {
-      const oldClaimable = randBigInt(0n, 1000n);
-      const newClaimable = oldClaimable + randBigInt(0n, 1000n);
+      const amount = randBigInt(0n, 1000n);
       const event: ClaimableIncreasedEvent = {
         txHash: randomHash(),
         account: randomAddress(),
-        oldClaimable,
-        newClaimable,
+        amount,
       };
       plugin.events.push(event);
 
@@ -152,8 +157,8 @@ async function generateFakeData(
         executor.developerAddress,
         developerTotal +
           scaleDecimals(
-            newClaimable - oldClaimable,
-            config.telToken[plugin.chain].decimals,
+            amount,
+            telTokenFor(plugin.chain).decimals,
             config.canonicalDecimals
           )
       );

--- a/backend/test/StakerIncentivesCalculator.test.ts
+++ b/backend/test/StakerIncentivesCalculator.test.ts
@@ -538,7 +538,12 @@ describe("StakerIncentivesCalculator", () => {
     }
 
     beforeEach(() => {
-      jest.spyOn(calculator, "fetchUserFeeTransfers").mockResolvedValue([]);
+      // These cases stub `fetchOnchainData`, so the transfers themselves are unused. One placeholder
+      // still stands in for a real fetch, since an empty result means a misconfigured period rather
+      // than a quiet one and is rejected before any reward is derived.
+      jest
+        .spyOn(calculator, "fetchUserFeeTransfers")
+        .mockResolvedValue([generateTestTokenTransfer(0, stakerA, stakerB)]);
     });
 
     it("should not apply the fee rebate cap when uncapped reward is below both stake cap and own fees", async () => {

--- a/backend/test/StakerIncentivesCalculator.test.ts
+++ b/backend/test/StakerIncentivesCalculator.test.ts
@@ -11,7 +11,7 @@ import { executors } from "../data/executors";
 import { amirXs } from "../data/amirXs";
 import { stakingModules } from "../data/stakingModules";
 import {
-  StakeChangedEvent,
+  VoteCheckpoint,
   StakerIncentivesCalculator,
 } from "../calculators/StakerIncentivesCalculator";
 import {
@@ -168,19 +168,26 @@ describe("StakerIncentivesCalculator", () => {
     );
 
     jest
-      .spyOn(calculator, "fetchStake")
+      .spyOn(calculator, "fetchVoteCheckpoints")
       .mockImplementation(
         async (
           client: PublicClient,
-          userAddress: Address,
-          endBlock: bigint,
-          stakingModuleContract: Address,
-        ): Promise<bigint> => {
-          if (userAddress.toString().startsWith(stakerSignal))
-            return Promise.resolve(getRandomBigInt(1, 2 ** 32));
-          else if (userAddress.toString().startsWith(nonstakerSignal))
-            return Promise.resolve(0n);
-          else throw new Error("Invalid test data for fetchStake");
+          account: Address,
+          stakingModule: Address,
+        ): Promise<VoteCheckpoint[]> => {
+          // a single checkpoint before the period means the stake was held for its entire
+          // duration, so the duration-weighted average is exactly that amount
+          if (account.toString().startsWith(stakerSignal))
+            return Promise.resolve([
+              {
+                blockNumber: arbitraryStartBlock - 1n,
+                votes: getRandomBigInt(1, 2 ** 32),
+              },
+            ]);
+          // an account that never staked has no checkpoints at all
+          else if (account.toString().startsWith(nonstakerSignal))
+            return Promise.resolve([]);
+          else throw new Error("Invalid test data for fetchVoteCheckpoints");
         },
       );
 
@@ -383,153 +390,119 @@ describe("StakerIncentivesCalculator", () => {
     }
   });
 
-  it("should return the correct average staked amount from a given set of events", async () => {
+  it("should compute the duration-weighted average stake from a checkpoint history", () => {
     const startBlock = 10n;
     const endBlock = 30n;
-    const accounts = [
-      getAddress("0x1111111111111111111111111111111111111111"),
-      getAddress("0x2222222222222222222222222222222222222222"),
-      getAddress("0x3333333333333333333333333333333333333333"),
-      getAddress("0x4444444444444444444444444444444444444444"),
-    ];
-    const accountsMap = new Map<
-      Address,
+
+    // A checkpoint at block `k` with value `v` means the account held `v` from `k` onward. The
+    // opening entry sits before `startBlock` and stands for stake carried into the period.
+    const cases: Array<{
+      name: string;
+      checkpoints: VoteCheckpoint[];
+      expectedAverageStakedAmount: bigint;
+    }> = [
       {
-        initialStakeAmount: bigint;
-        events: StakeChangedEvent[];
-        expectedAverageStakedAmount: bigint;
-      }
-    >([
-      //Even increasing stake
-      [
-        accounts[0],
-        {
-          initialStakeAmount: 500n,
-          events: [
-            {
-              account: accounts[0],
-              blockNumber: startBlock + 5n,
-              oldStake: 500n,
-              newStake: 1000n,
-            },
-            {
-              account: accounts[0],
-              blockNumber: startBlock + 10n,
-              oldStake: 1000n,
-              newStake: 1500n,
-            },
-            {
-              account: accounts[0],
-              blockNumber: startBlock + 15n,
-              oldStake: 1500n,
-              newStake: 2000n,
-            },
-          ],
-          expectedAverageStakedAmount: 1250n,
-        },
-      ],
-      //Uneven increasing stake
-      [
-        accounts[1],
-        {
-          initialStakeAmount: 800n,
-          events: [
-            {
-              account: accounts[1],
-              blockNumber: startBlock + 3n,
-              oldStake: 800n,
-              newStake: 1200n,
-            },
-            {
-              account: accounts[1],
-              blockNumber: startBlock + 8n,
-              oldStake: 1200n,
-              newStake: 1600n,
-            },
-            {
-              account: accounts[1],
-              blockNumber: startBlock + 12n,
-              oldStake: 1600n,
-              newStake: 2000n,
-            },
-          ],
-          expectedAverageStakedAmount: 1540n,
-        },
-      ],
-      //Even decreasing stake
-      [
-        accounts[2],
-        {
-          initialStakeAmount: 2000n,
-          events: [
-            {
-              account: accounts[2],
-              blockNumber: startBlock + 5n,
-              oldStake: 2000n,
-              newStake: 1500n,
-            },
-            {
-              account: accounts[2],
-              blockNumber: startBlock + 10n,
-              oldStake: 1500n,
-              newStake: 1000n,
-            },
-            {
-              account: accounts[2],
-              blockNumber: startBlock + 15n,
-              oldStake: 1000n,
-              newStake: 500n,
-            },
-          ],
-          expectedAverageStakedAmount: 1250n,
-        },
-      ],
-      //Uneven decreasing stake
-      [
-        accounts[3],
-        {
-          initialStakeAmount: 2000n,
-          events: [
-            {
-              account: accounts[3],
-              blockNumber: startBlock + 3n,
-              oldStake: 2000n,
-              newStake: 1600n,
-            },
-            {
-              account: accounts[3],
-              blockNumber: startBlock + 8n,
-              oldStake: 1600n,
-              newStake: 1200n,
-            },
-            {
-              account: accounts[3],
-              blockNumber: startBlock + 12n,
-              oldStake: 1200n,
-              newStake: 800n,
-            },
-          ],
-          expectedAverageStakedAmount: 1260n,
-        },
-      ],
-    ]);
+        name: "even increasing stake",
+        checkpoints: [
+          { blockNumber: startBlock - 9n, votes: 500n },
+          { blockNumber: startBlock + 5n, votes: 1000n },
+          { blockNumber: startBlock + 10n, votes: 1500n },
+          { blockNumber: startBlock + 15n, votes: 2000n },
+        ],
+        expectedAverageStakedAmount: 1250n,
+      },
+      {
+        name: "uneven increasing stake",
+        checkpoints: [
+          { blockNumber: startBlock - 9n, votes: 800n },
+          { blockNumber: startBlock + 3n, votes: 1200n },
+          { blockNumber: startBlock + 8n, votes: 1600n },
+          { blockNumber: startBlock + 12n, votes: 2000n },
+        ],
+        expectedAverageStakedAmount: 1540n,
+      },
+      {
+        name: "even decreasing stake",
+        checkpoints: [
+          { blockNumber: startBlock - 9n, votes: 2000n },
+          { blockNumber: startBlock + 5n, votes: 1500n },
+          { blockNumber: startBlock + 10n, votes: 1000n },
+          { blockNumber: startBlock + 15n, votes: 500n },
+        ],
+        expectedAverageStakedAmount: 1250n,
+      },
+      {
+        name: "uneven decreasing stake",
+        checkpoints: [
+          { blockNumber: startBlock - 9n, votes: 2000n },
+          { blockNumber: startBlock + 3n, votes: 1600n },
+          { blockNumber: startBlock + 8n, votes: 1200n },
+          { blockNumber: startBlock + 12n, votes: 800n },
+        ],
+        expectedAverageStakedAmount: 1260n,
+      },
+    ];
 
-    const allEvents = [...accountsMap.values()].flatMap(
-      (entry) => entry.events,
-    );
-
-    const result = await calculator.CalculateAvgStakedAmountsPerAccount(
-      allEvents,
-      startBlock,
-      endBlock,
-    );
-
-    for (const [
-      account,
-      { expectedAverageStakedAmount },
-    ] of accountsMap.entries()) {
-      expect(result.get(account)).toEqual(expectedAverageStakedAmount);
+    for (const { checkpoints, expectedAverageStakedAmount } of cases) {
+      expect(
+        calculator.durationWeightedStake(checkpoints, startBlock, endBlock),
+      ).toEqual(expectedAverageStakedAmount);
     }
+  });
+
+  it("should weight stake held for only part of the period", () => {
+    const startBlock = 100n;
+    const endBlock = 200n;
+
+    // no history at all: never staked
+    expect(calculator.durationWeightedStake([], startBlock, endBlock)).toEqual(
+      0n,
+    );
+
+    // staked at the halfway point and held to the end
+    expect(
+      calculator.durationWeightedStake(
+        [{ blockNumber: 150n, votes: 1000n }],
+        startBlock,
+        endBlock,
+      ),
+    ).toEqual(500n);
+
+    // held from before the period and fully unstaked at the halfway point
+    expect(
+      calculator.durationWeightedStake(
+        [
+          { blockNumber: 50n, votes: 1000n },
+          { blockNumber: 150n, votes: 0n },
+        ],
+        startBlock,
+        endBlock,
+      ),
+    ).toEqual(500n);
+
+    // checkpoints after the period are not in scope
+    expect(
+      calculator.durationWeightedStake(
+        [
+          { blockNumber: 50n, votes: 1000n },
+          { blockNumber: 500n, votes: 9999n },
+        ],
+        startBlock,
+        endBlock,
+      ),
+    ).toEqual(1000n);
+
+    // out-of-order input is normalized before weighting
+    expect(
+      calculator.durationWeightedStake(
+        [
+          { blockNumber: 150n, votes: 0n },
+          { blockNumber: 50n, votes: 1000n },
+        ],
+        startBlock,
+        endBlock,
+      ),
+    ).toEqual(500n);
   });
 
   describe("calculateRewardsPerStaker - fee rebate cap", () => {

--- a/script/DeployTANIssuanceHistory.s.sol
+++ b/script/DeployTANIssuanceHistory.s.sol
@@ -44,7 +44,7 @@ contract DeployTANIssuanceHistory is Script {
         vm.stopBroadcast();
 
         // asserts
-        assert(tanIssuanceHistory.tel() == tel);
+        assert(tanIssuanceHistory.tel() == address(tel));
         assert(tanIssuanceHistory.owner() == owner);
         assert(tanIssuanceHistory.tanIssuancePlugin() == tanIssuancePlugin);
         assert(tanIssuanceHistory.clock() == block.number);

--- a/src/interfaces/ISimplePlugin.sol
+++ b/src/interfaces/ISimplePlugin.sol
@@ -2,11 +2,41 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+/**
+ * @title ISimplePlugin
+ * @notice The subset of the V3 `SimplePlugin` surface that `TANIssuanceHistory` depends on.
+ *
+ * @dev `increaseClaimableBy` and `increaseClaimableByBatch` are `payable` because a plugin may pay
+ * rewards in the chain's native asset, in which case it is funded through `msg.value`. TAN issuance
+ * settles in TEL, so every call this repo makes passes zero value; `TANIssuanceHistory` rejects a
+ * native-reward plugin outright.
+ *
+ * `rewardToken()` returns either an ERC-20 address or the native sentinel
+ * `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`.
+ */
 interface ISimplePlugin is IERC165 {
-    function increaseClaimableBy(address account, uint256 amount) external returns (bool);
-    function tel() external view returns (IERC20);
+    /// @notice Credit a single `account` by `amount`, funded by one inbound transfer.
+    function increaseClaimableBy(address account, uint256 amount) external payable returns (bool);
+
+    /**
+     * @notice Credit many `accounts` by `amounts` from a single transfer of `totalAmount`.
+     * @dev `totalAmount` must equal the sum of `amounts`; the plugin reverts otherwise. Rows with a
+     * zero amount are skipped. An empty batch reverts, so callers must guard on length.
+     */
+    function increaseClaimableByBatch(
+        address[] calldata accounts,
+        uint256[] calldata amounts,
+        uint256 totalAmount
+    )
+        external
+        payable
+        returns (bool);
+
+    /// @notice The token this plugin pays rewards in, or the native sentinel.
+    function rewardToken() external view returns (address);
+
     function totalClaimable() external view returns (uint256);
+
     function deactivated() external view returns (bool);
 }

--- a/src/issuance/TANIssuanceHistory.sol
+++ b/src/issuance/TANIssuanceHistory.sol
@@ -27,26 +27,64 @@ contract TANIssuanceHistory is Ownable {
     error InvalidAddress(address invalidAddress);
     error InvalidBlock(uint256 endBlock);
     error FutureLookup(uint256 queriedBlock, uint48 clockBlock);
-    error IncreaseClaimableByFailed(address account, uint256 amount);
+    error IncreaseClaimableByBatchFailed();
+    error UnexpectedNative();
+    error BackfillIsSealed();
+    error BackfillLengthMismatch(uint256 accountsLength, uint256 amountsLength);
 
     struct IssuanceReward {
         address account;
         uint256 amount;
     }
 
+    /// @dev Sentinel a plugin reports from `rewardToken()` when it pays rewards in the chain's
+    /// native asset, which is how TEL presents itself on a chain where it is the gas token.
+    address private constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
     ISimplePlugin public tanIssuancePlugin;
-    IERC20 public immutable tel;
+
+    /// @notice The reward token this contract settles in: an ERC20 address, or `NATIVE_TOKEN` on a
+    /// chain where TEL is native.
+    address public immutable tel;
+
+    /// @notice Whether `tel` is the chain's native asset rather than an ERC20.
+    /// @dev Fixed at construction from the plugin's `rewardToken()`, and decides which funding rail
+    /// settlement uses: native is forwarded as `msg.value`, ERC20 is approved and pulled.
+    bool public immutable telIsNative;
 
     mapping(address => Checkpoints.Trace224) private _cumulativeRewards;
 
     uint256 public lastSettlementBlock;
 
+    /// @notice Once true, `backfillCumulativeRewards` is permanently disabled
+    /// @dev Set by `sealBackfill`, and automatically by the first settlement that credits anyone
+    bool public backfillSealed;
+
     /// @notice Emitted when users' (temporarily mocked) claimable rewards are increased
     event ClaimableIncreased(address indexed account, uint256 oldClaimable, uint256 newClaimable);
 
+    /// @notice Emitted for each account seeded with reward history carried over from a predecessor
+    event CumulativeRewardsBackfilled(address indexed account, uint256 amount, uint256 atBlock);
+
+    /// @notice Emitted when the backfill path is permanently closed
+    event BackfillSealed();
+
     constructor(ISimplePlugin tanIssuancePlugin_, address owner_) Ownable(owner_) {
         tanIssuancePlugin = tanIssuancePlugin_;
-        tel = tanIssuancePlugin.tel();
+
+        address rewardToken = tanIssuancePlugin_.rewardToken();
+        // a plugin reporting no reward token at all is misconfigured, whichever rail it uses
+        if (rewardToken == address(0x0)) revert InvalidAddress(rewardToken);
+
+        tel = rewardToken;
+        telIsNative = rewardToken == NATIVE_TOKEN;
+    }
+
+    /// @notice Accepts the native reward funding that settlement forwards to the plugin
+    /// @dev Only meaningful when TEL is the chain's native asset. On an ERC20 deployment there is no
+    /// reason for native to arrive here, so it is refused rather than silently accumulated.
+    receive() external payable {
+        if (!telIsNative) revert UnexpectedNative();
     }
 
     /**
@@ -101,6 +139,9 @@ contract TANIssuanceHistory is Ownable {
      */
 
     /// @dev Saves the settlement block, updates cumulative rewards history, and settles TEL rewards on the plugin
+    /// @notice An empty `rewards` array advances `lastSettlementBlock` without moving any TEL, which is how a
+    /// settlement gap is closed. `endBlock` may equal `lastSettlementBlock` so that one period can be settled as
+    /// several chunked transactions that all carry the same end block.
     function increaseClaimableByBatch(IssuanceReward[] calldata rewards, uint256 endBlock) external onlyOwner {
         // ensure temporal ordering of reward settlements
         if (endBlock < lastSettlementBlock || endBlock > block.number) revert InvalidBlock(endBlock);
@@ -108,27 +149,120 @@ contract TANIssuanceHistory is Ownable {
 
         uint256 totalAmount = 0;
         uint256 len = rewards.length;
+        // the plugin credits parallel arrays, so unpack the structs while accumulating history
+        address[] memory accounts = new address[](len);
+        uint256[] memory amounts = new uint256[](len);
         for (uint256 i; i < len; ++i) {
-            totalAmount += rewards[i].amount;
-            _incrementCumulativeRewards(rewards[i].account, rewards[i].amount, endBlock);
+            address account = rewards[i].account;
+            uint256 amount = rewards[i].amount;
+
+            accounts[i] = account;
+            amounts[i] = amount;
+
+            totalAmount += amount;
+            _incrementCumulativeRewards(account, amount, endBlock);
         }
 
-        // cache plugin in memory, set approval as `SimplePlugin::increaseClaimableBy()` pulls TEL from this address
-        ISimplePlugin plugin = tanIssuancePlugin;
-        tel.approve(address(plugin), totalAmount);
-        for (uint256 i; i < len; ++i) {
-            // event emission on this contract is omitted since the plugin emits a `ClaimableIncreased` event
-            bool success = plugin.increaseClaimableBy(rewards[i].account, rewards[i].amount);
-            if (!success) revert IncreaseClaimableByFailed(rewards[i].account, rewards[i].amount);
+        // the plugin rejects an empty batch, and a settlement with no recipients has nothing to fund,
+        // so skip the plugin entirely rather than funding and calling into it
+        if (len != 0) {
+            // cache plugin in memory; either rail moves exactly `totalAmount` out of this contract
+            ISimplePlugin plugin = tanIssuancePlugin;
+            // event emission on this contract is omitted since the plugin emits a `ClaimableIncreased`
+            // event per credited account. The plugin reverts on every failure path; the bool is a
+            // vestigial success signal that is checked anyway.
+            bool success;
+            if (telIsNative) {
+                // native rewards are funded by the call itself, so no approval is involved
+                success = plugin.increaseClaimableByBatch{ value: totalAmount }(accounts, amounts, totalAmount);
+            } else {
+                // set approval as the plugin pulls `totalAmount` from this address
+                IERC20(tel).forceApprove(address(plugin), totalAmount);
+                success = plugin.increaseClaimableByBatch(accounts, amounts, totalAmount);
+                // a conforming plugin consumes the allowance exactly; clearing it regardless means a
+                // plugin that under-pulls cannot leave a standing claim on this contract's balance
+                IERC20(tel).forceApprove(address(plugin), 0);
+            }
+            if (!success) revert IncreaseClaimableByBatchFailed();
+
+            // Settling creates history, and `backfillCumulativeRewards` skips any account that already
+            // carries history. Were a backfill to run after this point it would silently drop every
+            // account settled in the interim, overstating their reward caps for good, so the first
+            // settlement closes the backfill permanently.
+            if (!backfillSealed) {
+                backfillSealed = true;
+
+                emit BackfillSealed();
+            }
         }
     }
 
     /// @dev Permissioned function to set a new issuance plugin
+    /// @notice Comparing the reward token also pins the funding rail, since a native plugin reports
+    /// the native sentinel and an ERC20 plugin reports a token address
     function setTanIssuancePlugin(ISimplePlugin newPlugin) external onlyOwner {
-        if (newPlugin.tel() != tel) {
+        if (newPlugin.rewardToken() != tel) {
             revert IncompatiblePlugin();
         }
         tanIssuancePlugin = newPlugin;
+    }
+
+    /**
+     * @notice Seeds reward history for accounts that accrued TAN rewards under a predecessor contract
+     * @dev Owner-only, and disabled for good by `sealBackfill` or by the first settlement that credits
+     * anyone. An account that already carries history is skipped rather than overwritten, so a backfill
+     * split across several transactions can be retried safely without double counting. That skip is also
+     * why settlement closes this path: an account settled midway through a chunked backfill would be
+     * skipped by the remaining chunks and lose its carried-over history silently.
+     *
+     * Every entry is written at the single key `atBlock`, which becomes the new `lastSettlementBlock`.
+     * `cumulativeRewardsAtBlock` therefore reports zero for any block below `atBlock`; queries at or above
+     * it return the carried-over totals. Callers must supply `cumulativeAmounts` already denominated in the
+     * reward token this contract settles in.
+     *
+     * @param accounts Accounts to seed, aligned with `cumulativeAmounts`
+     * @param cumulativeAmounts Lifetime cumulative reward per account. A zero entry is skipped.
+     * @param atBlock Block the seeded checkpoints are keyed at. Must not precede `lastSettlementBlock`.
+     */
+    function backfillCumulativeRewards(
+        address[] calldata accounts,
+        uint256[] calldata cumulativeAmounts,
+        uint256 atBlock
+    )
+        external
+        onlyOwner
+    {
+        if (backfillSealed) revert BackfillIsSealed();
+        if (accounts.length != cumulativeAmounts.length) {
+            revert BackfillLengthMismatch(accounts.length, cumulativeAmounts.length);
+        }
+        // keep checkpoint keys ordered against any settlement that already landed
+        if (atBlock < lastSettlementBlock || atBlock > block.number) revert InvalidBlock(atBlock);
+
+        uint256 len = accounts.length;
+        for (uint256 i; i < len; ++i) {
+            uint256 amount = cumulativeAmounts[i];
+            if (amount == 0) continue;
+
+            address account = accounts[i];
+            if (account == address(0x0)) revert InvalidAddress(account);
+            // an account with existing history is authoritative and is never overwritten
+            if (_cumulativeRewards[account].latest() != 0) continue;
+
+            _cumulativeRewards[account].push(SafeCast.toUint32(atBlock), SafeCast.toUint224(amount));
+
+            emit CumulativeRewardsBackfilled(account, amount, atBlock);
+        }
+
+        lastSettlementBlock = atBlock;
+    }
+
+    /// @notice Permanently closes the backfill path
+    /// @dev One-way. Call once the seeded history has been reconciled against its source.
+    function sealBackfill() external onlyOwner {
+        backfillSealed = true;
+
+        emit BackfillSealed();
     }
 
     /// @notice Rescues any tokens stuck on this contract

--- a/test/TANIssuanceHistoryForkTest.t.sol
+++ b/test/TANIssuanceHistoryForkTest.t.sol
@@ -45,7 +45,7 @@ contract TANIssuanceHistoryForkTest is Test {
         deployments = abi.decode(data, (Deployments));
 
         plugin = ISimplePlugin(deployments.TANIssuancePlugin);
-        tanIssuanceHistory = TANIssuanceHistory(deployments.TANIssuanceHistory);
+        tanIssuanceHistory = TANIssuanceHistory(payable(deployments.TANIssuanceHistory));
 
         amirX = MockAmirX(deployments.mockAmirX);
         tel = ERC20(deployments.polygonTEL);
@@ -118,20 +118,22 @@ contract TANIssuanceHistoryForkTest is Test {
         endBlock = block.number;
 
         // distribute rewards (funds come from TAN safe)
+        uint256 historyBalanceBefore = tel.balanceOf(address(tanIssuanceHistory));
+        uint256 pluginBalanceBefore = tel.balanceOf(address(plugin));
         vm.prank(tanSafe);
         tel.transfer(address(tanIssuanceHistory), userFeeVolume);
 
-        // pre-settlement sanity asserts
-        assertEq(tel.balanceOf(address(tanIssuanceHistory)), userFeeVolume);
-        assertEq(tel.balanceOf(address(plugin)), 0);
+        // pre-settlement sanity assert
+        assertEq(tel.balanceOf(address(tanIssuanceHistory)), historyBalanceBefore + userFeeVolume);
 
         // owner of TANIssuanceHistory contract is configured as TAN safe
         vm.prank(tanSafe);
         tanIssuanceHistory.increaseClaimableByBatch(rewards, endBlock);
 
-        // asserts
-        assertEq(tel.balanceOf(address(tanIssuanceHistory)), 0);
-        assertEq(tel.balanceOf(address(plugin)), userFeeVolume);
+        /// @dev the fork runs against live state at whatever block it was created at, so balances are
+        /// asserted as deltas rather than absolutes
+        assertEq(tel.balanceOf(address(tanIssuanceHistory)), historyBalanceBefore);
+        assertEq(tel.balanceOf(address(plugin)), pluginBalanceBefore + userFeeVolume);
         assertEq(tanIssuanceHistory.lastSettlementBlock(), endBlock);
         assertEq(tanIssuanceHistory.cumulativeRewards(user), userReward);
     }

--- a/test/TANIssuanceHistoryTest.t.sol
+++ b/test/TANIssuanceHistoryTest.t.sol
@@ -38,6 +38,9 @@ contract TANIssuanceHistoryTest is Test {
 
         // Deploy the TANIssuanceHistory contract as owner
         tanIssuanceHistory = new TANIssuanceHistory(mockPlugin, owner);
+
+        // settlement funds are transferred to this contract before each batch and pulled by the plugin
+        tel.mint(address(tanIssuanceHistory), 1e30);
     }
 
     /// @dev Useful as a benchmark for the maximum batch size which is ~15000 users
@@ -122,13 +125,12 @@ contract TANIssuanceHistoryTest is Test {
         uint256 referrerEligibility = userFeeVolume;
         uint256 totalEligibleVolume = userFeeVolume + referrerEligibility;
 
+        // stake history is only queryable for finalized blocks, so settle a block past the swap
+        vm.roll(block.number + 1);
+
         // derive reward caps
-        uint256 stakedByUser = stakingModule.stakedByAt(user, block.number);
-        uint256 prevUserRewards = tanIssuanceHistory.cumulativeRewardsAtBlock(user, block.number);
-        uint256 userRewardCap = stakedByUser - prevUserRewards;
-        uint256 stakedByReferrer = stakingModule.stakedByAt(referrer, block.number);
-        uint256 prevReferrerRewards = tanIssuanceHistory.cumulativeRewardsAtBlock(referrer, block.number);
-        uint256 referrerRewardCap = stakedByReferrer - prevReferrerRewards;
+        uint256 userRewardCap = _rewardCap(user);
+        uint256 referrerRewardCap = _rewardCap(referrer);
 
         // calculator uses a very large scaling factor to address arithmetic decimal precision
         uint256 scalingFactor = 1_000_000_000_000_000;
@@ -158,5 +160,412 @@ contract TANIssuanceHistoryTest is Test {
         assertEq(tanIssuanceHistory.lastSettlementBlock(), endBlock);
         assertEq(tanIssuanceHistory.cumulativeRewards(user), userReward);
         assertEq(tanIssuanceHistory.cumulativeRewards(referrer), referrerReward);
+    }
+
+    /**
+     * Settlement edge cases
+     */
+
+    /// @dev The settlement entrypoint is consumed by an offchain builder and a Safe UI, so its
+    /// selector is part of the operational contract and must survive plugin changes.
+    function testSettlementSelectorIsStable() public pure {
+        assertEq(uint32(TANIssuanceHistory.increaseClaimableByBatch.selector), uint32(0x8bf2e6a1));
+    }
+
+    /// @dev An empty batch is how a settlement gap is closed, so it must advance the block without
+    /// touching the plugin, which rejects empty batches outright.
+    function testEmptyBatchAdvancesSettlementBlockWithoutTouchingPlugin() public {
+        uint256 balanceBefore = tel.balanceOf(address(tanIssuanceHistory));
+        uint256 targetBlock = block.number + 500;
+        vm.roll(targetBlock);
+
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](0);
+        vm.prank(owner);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, targetBlock);
+
+        assertEq(tanIssuanceHistory.lastSettlementBlock(), targetBlock);
+        assertEq(tel.balanceOf(address(tanIssuanceHistory)), balanceBefore);
+        assertEq(MockPlugin(address(mockPlugin)).totalClaimable(), 0);
+    }
+
+    /// @dev The gap-closing path has to keep working after the plugin winds down, which is only
+    /// true while an empty batch skips the plugin entirely.
+    function testEmptyBatchSucceedsWhenPluginDeactivated() public {
+        MockPlugin(address(mockPlugin)).setDeactivated(true);
+
+        uint256 targetBlock = block.number + 500;
+        vm.roll(targetBlock);
+
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](0);
+        vm.prank(owner);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, targetBlock);
+
+        assertEq(tanIssuanceHistory.lastSettlementBlock(), targetBlock);
+    }
+
+    /// @dev One period may be settled as several transactions sharing an end block.
+    function testChunkedDistributionSameEndBlock() public {
+        uint256 endBlock = block.number;
+
+        TANIssuanceHistory.IssuanceReward[] memory chunkOne = new TANIssuanceHistory.IssuanceReward[](1);
+        chunkOne[0] = TANIssuanceHistory.IssuanceReward(user1, 100);
+        TANIssuanceHistory.IssuanceReward[] memory chunkTwo = new TANIssuanceHistory.IssuanceReward[](1);
+        chunkTwo[0] = TANIssuanceHistory.IssuanceReward(user2, 200);
+
+        vm.startPrank(owner);
+        tanIssuanceHistory.increaseClaimableByBatch(chunkOne, endBlock);
+        tanIssuanceHistory.increaseClaimableByBatch(chunkTwo, endBlock);
+        vm.stopPrank();
+
+        assertEq(tanIssuanceHistory.cumulativeRewards(user1), 100);
+        assertEq(tanIssuanceHistory.cumulativeRewards(user2), 200);
+        assertEq(tanIssuanceHistory.lastSettlementBlock(), endBlock);
+    }
+
+    /// @dev A repeated account accumulates on both this contract and the plugin.
+    function testDuplicateAccountInSameBatch() public {
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](2);
+        rewards[0] = TANIssuanceHistory.IssuanceReward(user1, 100);
+        rewards[1] = TANIssuanceHistory.IssuanceReward(user1, 250);
+
+        vm.prank(owner);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, block.number);
+
+        assertEq(tanIssuanceHistory.cumulativeRewards(user1), 350);
+        assertEq(MockPlugin(address(mockPlugin)).claimable(user1), 350);
+    }
+
+    /// @dev A zero-amount row is credited nowhere but must not abort the surrounding batch.
+    function testZeroAmountRowIsSkippedByPlugin() public {
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](2);
+        rewards[0] = TANIssuanceHistory.IssuanceReward(user1, 0);
+        rewards[1] = TANIssuanceHistory.IssuanceReward(user2, 200);
+
+        vm.prank(owner);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, block.number);
+
+        assertEq(tanIssuanceHistory.cumulativeRewards(user1), 0);
+        assertEq(tanIssuanceHistory.cumulativeRewards(user2), 200);
+        assertEq(MockPlugin(address(mockPlugin)).totalClaimable(), 200);
+    }
+
+    /// @dev Exactly the settled total is pulled, leaving no standing allowance behind.
+    function testSettlementPullsExactTotalAndClearsAllowance() public {
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](2);
+        rewards[0] = TANIssuanceHistory.IssuanceReward(user1, 100);
+        rewards[1] = TANIssuanceHistory.IssuanceReward(user2, 200);
+
+        uint256 historyBefore = tel.balanceOf(address(tanIssuanceHistory));
+
+        vm.prank(owner);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, block.number);
+
+        assertEq(tel.balanceOf(address(mockPlugin)), 300);
+        assertEq(tel.balanceOf(address(tanIssuanceHistory)), historyBefore - 300);
+        assertEq(tel.allowance(address(tanIssuanceHistory), address(mockPlugin)), 0);
+    }
+
+    function testConstructorRejectsPluginWithNoRewardToken() public {
+        MockPlugin brokenPlugin = new MockPlugin(IERC20(address(0x0)));
+
+        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.InvalidAddress.selector, address(0x0)));
+        new TANIssuanceHistory(ISimplePlugin(address(brokenPlugin)), owner);
+    }
+
+    /**
+     * Native reward token
+     *
+     * On a chain where TEL is the gas token the plugin reports the native sentinel and is funded by
+     * `msg.value` rather than an approval, so settlement takes the other rail.
+     */
+
+    function testNativeDeploymentReportsNativeRail() public {
+        (TANIssuanceHistory nativeHistory,) = _deployNative();
+
+        assertEq(nativeHistory.tel(), MockPlugin(address(mockPlugin)).NATIVE_TOKEN());
+        assertTrue(nativeHistory.telIsNative());
+        assertFalse(tanIssuanceHistory.telIsNative());
+    }
+
+    function testNativeSettlementForwardsValueToPlugin() public {
+        (TANIssuanceHistory nativeHistory, MockPlugin nativePlugin) = _deployNative();
+
+        // the Safe funds the history contract ahead of settlement, exactly as it does for ERC20
+        vm.deal(address(nativeHistory), 1 ether);
+
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](2);
+        rewards[0] = TANIssuanceHistory.IssuanceReward(user1, 100);
+        rewards[1] = TANIssuanceHistory.IssuanceReward(user2, 200);
+
+        vm.prank(owner);
+        nativeHistory.increaseClaimableByBatch(rewards, block.number);
+
+        assertEq(address(nativePlugin).balance, 300);
+        assertEq(address(nativeHistory).balance, 1 ether - 300);
+        assertEq(nativeHistory.cumulativeRewards(user1), 100);
+        assertEq(nativePlugin.claimable(user2), 200);
+    }
+
+    /// @dev The gap-closing path must not send value when there is nothing to settle.
+    function testNativeEmptyBatchMovesNothing() public {
+        (TANIssuanceHistory nativeHistory, MockPlugin nativePlugin) = _deployNative();
+        vm.deal(address(nativeHistory), 1 ether);
+
+        uint256 targetBlock = block.number + 500;
+        vm.roll(targetBlock);
+
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](0);
+        vm.prank(owner);
+        nativeHistory.increaseClaimableByBatch(rewards, targetBlock);
+
+        assertEq(address(nativeHistory).balance, 1 ether);
+        assertEq(address(nativePlugin).balance, 0);
+        assertEq(nativeHistory.lastSettlementBlock(), targetBlock);
+    }
+
+    function testNativeDeploymentAcceptsNativeFunding() public {
+        (TANIssuanceHistory nativeHistory,) = _deployNative();
+
+        (bool sent,) = address(nativeHistory).call{ value: 1 ether }("");
+        assertTrue(sent);
+        assertEq(address(nativeHistory).balance, 1 ether);
+    }
+
+    /// @dev An ERC20 deployment has no use for native, so it refuses it rather than accruing dust.
+    function testErc20DeploymentRefusesNativeFunding() public {
+        vm.deal(address(this), 1 ether);
+
+        (bool sent,) = address(tanIssuanceHistory).call{ value: 1 ether }("");
+        assertFalse(sent);
+        assertEq(address(tanIssuanceHistory).balance, 0);
+    }
+
+    /// @dev The rails must not be swapped under a live deployment, which the reward token check pins.
+    function testNativeDeploymentRejectsErc20Plugin() public {
+        (TANIssuanceHistory nativeHistory,) = _deployNative();
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.IncompatiblePlugin.selector));
+        nativeHistory.setTanIssuancePlugin(mockPlugin);
+    }
+
+    function _deployNative() private returns (TANIssuanceHistory, MockPlugin) {
+        MockPlugin nativePlugin = new MockPlugin(IERC20(MockPlugin(address(mockPlugin)).NATIVE_TOKEN()));
+        TANIssuanceHistory nativeHistory = new TANIssuanceHistory(ISimplePlugin(address(nativePlugin)), owner);
+
+        return (nativeHistory, nativePlugin);
+    }
+
+    function testSetTanIssuancePluginRejectsMismatchedRewardToken() public {
+        MockTel otherToken = new MockTel("Other", "OTH");
+        MockPlugin otherPlugin = new MockPlugin(IERC20(address(otherToken)));
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.IncompatiblePlugin.selector));
+        tanIssuanceHistory.setTanIssuancePlugin(ISimplePlugin(address(otherPlugin)));
+    }
+
+    function testSetTanIssuancePluginAcceptsMatchingRewardToken() public {
+        MockPlugin replacement = new MockPlugin(IERC20(address(tel)));
+
+        vm.prank(owner);
+        tanIssuanceHistory.setTanIssuancePlugin(ISimplePlugin(address(replacement)));
+
+        assertEq(address(tanIssuanceHistory.tanIssuancePlugin()), address(replacement));
+    }
+
+    /**
+     * Backfill
+     */
+
+    function testBackfillSeedsHistoryAndAdvancesSettlementBlock() public {
+        uint256 atBlock = block.number + 10;
+        vm.roll(atBlock + 1);
+
+        (address[] memory accounts, uint256[] memory amounts) = _pair(user1, 1000, user2, 2500);
+
+        vm.prank(owner);
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, atBlock);
+
+        assertEq(tanIssuanceHistory.cumulativeRewards(user1), 1000);
+        assertEq(tanIssuanceHistory.cumulativeRewards(user2), 2500);
+        assertEq(tanIssuanceHistory.lastSettlementBlock(), atBlock);
+        // seeded history is only visible from the block it was keyed at
+        assertEq(tanIssuanceHistory.cumulativeRewardsAtBlock(user1, atBlock - 1), 0);
+        assertEq(tanIssuanceHistory.cumulativeRewardsAtBlock(user1, atBlock), 1000);
+        // no reward token moves during a backfill
+        assertEq(tel.balanceOf(address(mockPlugin)), 0);
+    }
+
+    /// @dev A chunked backfill must be safe to retry, so an account that already carries history is
+    /// left untouched rather than overwritten.
+    function testBackfillNeverOverwritesExistingHistory() public {
+        (address[] memory accounts, uint256[] memory amounts) = _pair(user1, 1000, user2, 2500);
+
+        vm.startPrank(owner);
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, block.number);
+
+        amounts[0] = 999_999;
+        amounts[1] = 999_999;
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, block.number);
+        vm.stopPrank();
+
+        assertEq(tanIssuanceHistory.cumulativeRewards(user1), 1000);
+        assertEq(tanIssuanceHistory.cumulativeRewards(user2), 2500);
+    }
+
+    /// @dev Settling creates history, and the backfill skips accounts that already carry history. A
+    /// backfill running afterwards would silently drop everyone settled in between, so the first
+    /// settlement closes the path rather than leaving that trap open.
+    function testSettlementSealsBackfill() public {
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](1);
+        rewards[0] = TANIssuanceHistory.IssuanceReward(user1, 42);
+
+        vm.startPrank(owner);
+        assertFalse(tanIssuanceHistory.backfillSealed());
+
+        vm.expectEmit(false, false, false, false);
+        emit TANIssuanceHistory.BackfillSealed();
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, block.number);
+        assertTrue(tanIssuanceHistory.backfillSealed());
+
+        (address[] memory accounts, uint256[] memory amounts) = _pair(user2, 1000, referrer, 2500);
+        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.BackfillIsSealed.selector));
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, block.number);
+        vm.stopPrank();
+    }
+
+    /// @dev A gap-closing empty batch credits nobody, so it leaves the backfill open.
+    function testEmptyBatchDoesNotSealBackfill() public {
+        uint256 targetBlock = block.number + 500;
+        vm.roll(targetBlock);
+
+        TANIssuanceHistory.IssuanceReward[] memory empty = new TANIssuanceHistory.IssuanceReward[](0);
+        (address[] memory accounts, uint256[] memory amounts) = _pair(user1, 1000, user2, 2500);
+
+        vm.startPrank(owner);
+        tanIssuanceHistory.increaseClaimableByBatch(empty, targetBlock);
+        assertFalse(tanIssuanceHistory.backfillSealed());
+
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, targetBlock);
+        vm.stopPrank();
+
+        assertEq(tanIssuanceHistory.cumulativeRewards(user1), 1000);
+    }
+
+    function testBackfillRejectsBlockBeforeLastSettlement() public {
+        uint256 firstBlock = block.number + 100;
+        vm.roll(firstBlock + 1);
+
+        (address[] memory accounts, uint256[] memory amounts) = _pair(user1, 1000, user2, 2500);
+
+        vm.startPrank(owner);
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, firstBlock);
+        assertEq(tanIssuanceHistory.lastSettlementBlock(), firstBlock);
+
+        (address[] memory more, uint256[] memory moreAmounts) = _pair(referrer, 1000, user, 2500);
+        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.InvalidBlock.selector, firstBlock - 1));
+        tanIssuanceHistory.backfillCumulativeRewards(more, moreAmounts, firstBlock - 1);
+        vm.stopPrank();
+    }
+
+    function testBackfillRejectsFutureBlock() public {
+        (address[] memory accounts, uint256[] memory amounts) = _pair(user1, 1000, user2, 2500);
+        uint256 futureBlock = block.number + 1;
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.InvalidBlock.selector, futureBlock));
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, futureBlock);
+    }
+
+    function testBackfillRejectsLengthMismatch() public {
+        address[] memory accounts = new address[](2);
+        accounts[0] = user1;
+        accounts[1] = user2;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1000;
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.BackfillLengthMismatch.selector, 2, 1));
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, block.number);
+    }
+
+    function testBackfillRejectsZeroAddressWithNonZeroAmount() public {
+        (address[] memory accounts, uint256[] memory amounts) = _pair(address(0x0), 1000, user2, 2500);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.InvalidAddress.selector, address(0x0)));
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, block.number);
+    }
+
+    function testBackfillIsOnlyOwner() public {
+        (address[] memory accounts, uint256[] memory amounts) = _pair(user1, 1000, user2, 2500);
+
+        vm.prank(user);
+        vm.expectRevert();
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, block.number);
+    }
+
+    function testSealBackfillIsOneWayAndBlocksFurtherBackfills() public {
+        (address[] memory accounts, uint256[] memory amounts) = _pair(user1, 1000, user2, 2500);
+
+        vm.startPrank(owner);
+        assertFalse(tanIssuanceHistory.backfillSealed());
+        tanIssuanceHistory.sealBackfill();
+        assertTrue(tanIssuanceHistory.backfillSealed());
+
+        // sealing twice is a no-op rather than a revert, so a retried seal transaction is harmless
+        tanIssuanceHistory.sealBackfill();
+        assertTrue(tanIssuanceHistory.backfillSealed());
+
+        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.BackfillIsSealed.selector));
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, block.number);
+        vm.stopPrank();
+    }
+
+    /// @dev Settlement continues normally once the backfill is closed.
+    function testSettlementAccumulatesOnTopOfBackfilledHistory() public {
+        (address[] memory accounts, uint256[] memory amounts) = _pair(user1, 1000, user2, 2500);
+
+        vm.startPrank(owner);
+        tanIssuanceHistory.backfillCumulativeRewards(accounts, amounts, block.number);
+        tanIssuanceHistory.sealBackfill();
+
+        vm.roll(block.number + 50);
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](1);
+        rewards[0] = TANIssuanceHistory.IssuanceReward(user1, 500);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, block.number);
+        vm.stopPrank();
+
+        assertEq(tanIssuanceHistory.cumulativeRewards(user1), 1500);
+        // only the newly settled amount is funded onto the plugin
+        assertEq(MockPlugin(address(mockPlugin)).claimable(user1), 500);
+    }
+
+    /// @dev The cap the offchain calculator applies: stake held over the period, less rewards
+    /// already issued to that account.
+    function _rewardCap(address account) private view returns (uint256) {
+        uint256 queryBlock = block.number - 1;
+
+        return stakingModule.getPastVotes(account, queryBlock)
+            - tanIssuanceHistory.cumulativeRewardsAtBlock(account, queryBlock);
+    }
+
+    function _pair(
+        address accountOne,
+        uint256 amountOne,
+        address accountTwo,
+        uint256 amountTwo
+    )
+        private
+        pure
+        returns (address[] memory accounts, uint256[] memory amounts)
+    {
+        accounts = new address[](2);
+        accounts[0] = accountOne;
+        accounts[1] = accountTwo;
+        amounts = new uint256[](2);
+        amounts[0] = amountOne;
+        amounts[1] = amountTwo;
     }
 }

--- a/test/mocks/MockImplementations.sol
+++ b/test/mocks/MockImplementations.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.26;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Checkpoints } from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "../../src/interfaces/ISimplePlugin.sol";
 
 /// @title Mock contracts for TANIssuanceHistory integration testing. Do NOT use any in production
@@ -61,52 +63,158 @@ contract MockTel is ERC20 {
 }
 
 /// @notice This contract did not need to be deployed for testing as one already exists
+/// @dev Mirrors the parts of the V3 `StakingModule` that reward tooling reads: sTEL is an
+/// `ERC20Votes` token, so per-account stake history is exposed as vote checkpoints keyed by block
+/// number. `Checkpoints.Trace208` is the same structure `ERC20VotesUpgradeable` uses, so
+/// `numCheckpoints` / `checkpoints` / `getPastVotes` behave as they do onchain.
 contract MockStakingModule {
-    event StakeChanged(address account, uint256 oldStake, uint256 newStake);
+    using Checkpoints for Checkpoints.Trace208;
 
-    mapping(address => uint256) _stakes;
+    error FutureLookup(uint256 queriedBlock, uint256 currentBlock);
+    error InsufficientStake(uint256 requested, uint256 available);
+
+    event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes);
+
+    mapping(address => Checkpoints.Trace208) private _votes;
 
     function stake(uint256 amount) external {
-        uint256 oldStake = _stakes[msg.sender];
-        uint256 newStake = _stakes[msg.sender] += amount;
-
-        emit StakeChanged(msg.sender, oldStake, newStake);
+        _moveVotes(msg.sender, _votes[msg.sender].latest() + amount);
     }
 
-    function stakedByAt(address account, uint256 blockNumber) public view returns (uint256) {
-        // ignore actual block number checkpoints
-        require(blockNumber <= block.number, "Future lookup");
+    function unstake(uint256 amount) external {
+        uint256 current = _votes[msg.sender].latest();
+        if (amount > current) revert InsufficientStake(amount, current);
 
-        return _stakes[account];
+        _moveVotes(msg.sender, current - amount);
+    }
+
+    function numCheckpoints(address account) external view returns (uint32) {
+        return SafeCast.toUint32(_votes[account].length());
+    }
+
+    function checkpoints(address account, uint32 pos) external view returns (Checkpoints.Checkpoint208 memory) {
+        return _votes[account].at(pos);
+    }
+
+    function getPastVotes(address account, uint256 blockNumber) external view returns (uint256) {
+        // matches `Votes.getPastVotes`, which only answers for finalized blocks
+        if (blockNumber >= block.number) revert FutureLookup(blockNumber, block.number);
+
+        return _votes[account].upperLookupRecent(SafeCast.toUint48(blockNumber));
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _votes[account].latest();
+    }
+
+    function _moveVotes(address account, uint256 newVotes) private {
+        uint256 previousVotes = _votes[account].latest();
+        _votes[account].push(SafeCast.toUint48(block.number), SafeCast.toUint208(newVotes));
+
+        emit DelegateVotesChanged(account, previousVotes, newVotes);
     }
 }
 
 /// @notice  This contract did not need to be deployed for testing as one already exists
+/// @dev Reproduces the V3 `SimplePlugin` funding semantics that `TANIssuanceHistory` relies on,
+/// including the single pull of `totalAmount` and every revert the batch path can raise.
 contract MockPlugin is ISimplePlugin {
+    using SafeERC20 for IERC20;
+
     error Deactivated();
+    error BatchLengthMismatch(uint256 accountsLength, uint256 amountsLength);
+    error EmptyBatch();
+    error BatchTotalMismatch(uint256 declaredTotal, uint256 summedAmounts);
+    error ZeroAddress();
+    error MsgValueMismatch(uint256 expected, uint256 actual);
+    error UnexpectedMsgValue();
+
+    event ClaimableIncreased(address indexed account, uint256 amount);
+
+    address public constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     bool public deactivated;
-    IERC20 public tel;
+    address public immutable rewardToken;
     uint256 public totalClaimable;
     mapping(address => uint256) public claimable;
 
     constructor(IERC20 tel_) {
-        tel = tel_;
+        rewardToken = address(tel_);
+    }
+
+    /// @dev A plugin paying the chain's native asset is funded by `msg.value` rather than a pull.
+    function isNative() public view returns (bool) {
+        return rewardToken == NATIVE_TOKEN;
     }
 
     function setDeactivated(bool newVal) external {
         deactivated = newVal;
     }
 
-    function increaseClaimableBy(address account, uint256 amount) external override returns (bool) {
+    function increaseClaimableBy(address account, uint256 amount) external payable override returns (bool) {
+        if (deactivated) revert Deactivated();
+        if (amount == 0) return false;
+        if (account == address(0x0)) revert ZeroAddress();
+
+        claimable[account] += amount;
+        totalClaimable += amount;
+        _receiveFunding(amount);
+
+        emit ClaimableIncreased(account, amount);
+        return true;
+    }
+
+    function increaseClaimableByBatch(
+        address[] calldata accounts,
+        uint256[] calldata amounts,
+        uint256 totalAmount
+    )
+        external
+        payable
+        override
+        returns (bool)
+    {
         if (deactivated) revert Deactivated();
 
-        // simplified mock implementation
-        claimable[account] += amount;
+        uint256 len = accounts.length;
+        if (len != amounts.length) revert BatchLengthMismatch(len, amounts.length);
+        if (len == 0) revert EmptyBatch();
+
+        uint256 summed;
+        for (uint256 i; i < len; ++i) {
+            uint256 amount = amounts[i];
+            if (amount == 0) continue;
+
+            address account = accounts[i];
+            if (account == address(0x0)) revert ZeroAddress();
+
+            claimable[account] += amount;
+            summed += amount;
+
+            emit ClaimableIncreased(account, amount);
+        }
+
+        if (summed != totalAmount) revert BatchTotalMismatch(totalAmount, summed);
+        totalClaimable += totalAmount;
+
+        _receiveFunding(totalAmount);
+
         return true;
     }
 
     function supportsInterface(bytes4) external pure returns (bool) {
         return true;
+    }
+
+    /// @dev Native funding arrives with the call; ERC20 funding is pulled from the caller.
+    function _receiveFunding(uint256 amount) private {
+        if (isNative()) {
+            if (msg.value != amount) revert MsgValueMismatch(amount, msg.value);
+        } else {
+            if (msg.value != 0) revert UnexpectedMsgValue();
+            if (amount > 0) {
+                IERC20(rewardToken).safeTransferFrom(msg.sender, address(this), amount);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why

`TANIssuanceHistory` is bound to the V2 `SimplePlugin` ABI, and the staker calculator reads a `StakingModule` surface that V3 removes. Neither survives the Tel V3 cutover as written:

- V3 exposes `rewardToken()` instead of `tel()`, so the constructor and `setTanIssuancePlugin` both revert against a V3 plugin. The contract is not upgradeable, so it must be redeployed.
- V3 deletes `StakeChanged` and `stakedByAt`. The V3 `StakingModule` *is* the sTEL ERC20, with vote checkpoints in place of stake checkpoints.
- TEL goes from 2 decimals to 18, so every stored cumulative reward is off by `1e16`.
- A redeployed contract starts with empty reward history, which would reset every wallet's reward cap to its full stake.

Decisions taken before implementation: reward caps read from `getPastVotes`-backed checkpoints (accepting that delegating sTEL reassigns reward share), and a hard cutover with no dual-read transition period.

## Contract

**ABI preserved.** All 15 pre-existing selectors are byte-identical, including `increaseClaimableByBatch` at `0x8bf2e6a1`. Additions are `backfillCumulativeRewards`, `backfillSealed`, `sealBackfill`, `telIsNative`, and a gated `receive`. There is a test asserting the settlement selector directly, and the fork test drives the **live V2 Polygon deployment** through the recompiled type as an independent check.

**Dual-rail settlement.** `tel` is now the reward token address (an ERC20, or the native sentinel) alongside an immutable `telIsNative`. Settlement forwards `msg.value` on a native chain and approves-and-pulls on an ERC20 chain. This keeps Telcoin Network open as a deployment target, where TEL is the gas token. `increaseClaimableByBatch` stays `nonpayable` and funds from the contract's own balance, so the Safe flow is unchanged.

**Batched settlement.** The per-recipient `increaseClaimableBy` loop collapses onto the V3 `increaseClaimableByBatch`, measured at roughly **4,900 gas saved per recipient** (~1.47M per 300-entry chunk). Two behaviours are load-bearing and covered by tests: an empty batch must skip the plugin entirely (the plugin rejects empty batches, and this is how a settlement gap is closed), and `endBlock == lastSettlementBlock` stays legal so one period can be settled as several chunks.

**Backfill.** `backfillCumulativeRewards` seeds carried-over history, skipping any account that already has history so a chunked backfill is safe to retry. The first settlement that credits anyone seals it automatically -- settling creates history, which the skip rule would then step around, silently dropping those accounts. An empty gap-closing batch does not seal.

## Calculator

Stake history now comes from the sTEL `ERC20Votes` checkpoints (`numCheckpoints` / `checkpoints`) rather than log replay. This removes `getLogs` from the path entirely, which retires the unchunked scan over a ~403k-block period, and it measures every account the same way instead of falling back to a point-in-time read for accounts with no in-window events.

The duration-weighting test was ported to checkpoint inputs while keeping its original expected values (1250 / 1540 / 1250 / 1260) as an equivalence check against the old event-replay logic.

## Backfill script

`backend/buildBackfill.ts` unions recipients across the period files, cross-checks them against the predecessor plugin's onchain credit logs, reads authoritative totals from the predecessor's own getter, rescales by `1e16`, and emits Safe chunks only once all three sources agree.

Dry run against live Polygon reconciles exactly:

```
period files : 8760382031
onchain logs : 8760382031
history getter: 8760382031
```

1,150 recipients, 87,603,820.31 TEL, 4 chunks.

## Fixed along the way

- `backend/abi/TanIssuanceHistoryAbi.ts` did not match the deployed contract on `master`. It declared `increaseClaimableByBatch(address[],uint256[])`, which is not the deployed signature. It survived only because the backend used it for reads while the write tx was hand-assembled in the Safe UI.
- RPC errors were swallowed into defaults on both reward-cap inputs. A failed stake read read as "unstaked" and paid nothing; a failed cumulative-rewards read read as "no prior rewards" and overpaid. Both now abort the run.
- The fork test asserted the live plugin holds exactly 0 TEL, which stopped being true once real distributions landed. Now asserted as deltas.
- The jest suite was unrunnable on `master` (`@types/jest` declared but not installed, so every suite failed to compile). With it running, two latent bugs surfaced in `DeveloperIncentivesCalculator.test.ts`: it generated plugins on Base, which has no TEL configured, and built 3 block databases against 2 start-block entries.

## Verification

- `forge test`: 32 passing, including the live-Polygon fork test
- `npx tsc --noEmit`: clean, including all 14 errors that existed on `master`
- `npx jest`: 46 passing across 7 suites

## Blocking before merge

1. **Period 42 is not on `master`.** The backfill's onchain cross-check caught this: 4 accounts were credited onchain but absent from the period files, all from one Safe tx at block 91156813. They are in `staker_rewards_period_42.json` on `telx-period-50-tan-period-42`. The backfill must not run until every published period file is merged, or those wallets get their caps reset to full stake.
2. **`POLYGON_TEL_V3` is unset** in `backend/config.ts`, since TelcoinV3 is not deployed to Polygon yet. `assertTelTokensConfigured` fails a period run while it is unset.
3. **AmirX blocks the referral leg.** `AmirX.sol:40` hardcodes `ERC20 public constant TELCOIN`, so all three live Polygon AmirX contracts need a new implementation plus a proxy upgrade. Ideally landing in the same window as the cutover, so no period straddles two fee tokens at two decimal scales. Out of scope here.
4. **Polygon V3 staking is not deployed**, and `tel-v3-staking` has no `SimplePlugin` deploy script (only `StreamingRewardsPlugin`). One is needed.

## Open questions

- `TANIssuanceHistory` still declares a never-emitted `ClaimableIncreased(address,uint256,uint256)`. Kept for ABI stability, but it now describes a shape nothing in the system emits and shares a name with the V3 plugin's real `(address,uint256)` event at a different topic0. Worth deleting if we would rather not leave that trap.
- Any UI reading credit or claim events needs auditing against the V3 topic0s before cutover. The failure mode is silent: a filter pinned to the old topic0 matches zero logs rather than erroring.
- Whether TAN issuance on Telcoin Network would pay native TEL or WTEL. `config.ts` currently says WTEL, but the plugin sentinel and WTEL are different answers and they pick different rails.
